### PR TITLE
Fix bug with signature pointer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -853,10 +853,10 @@ impl Ctx {
     match (self.C_Sign)(session, data.as_slice().as_ptr(), data.len(), ptr::null(), &mut signatureLen) {
       CKR_OK => {
         let mut signature: Vec<CK_BYTE> = Vec::with_capacity(signatureLen);
-        match (self.C_Sign)(session, data.as_slice().as_ptr(), data.len(), ptr::null(), &signatureLen) {
+        match (self.C_Sign)(session, data.as_slice().as_ptr(), data.len(), signature.as_slice().as_ptr(), &signatureLen) {
           CKR_OK => {
             unsafe {
-              signature.set_len(signatureLen); 
+              signature.set_len(signatureLen);
             }
             Ok(signature)
           },


### PR DESCRIPTION
The signature wasn't actually being populated during sign, only during sign_final.