### PR TITLE
Only apply packed structs on windows

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -20,6 +20,18 @@ macro_rules! packed_clone {
     )
 }
 
+// packed structs only needed on Windows, pkcs11.h mentions
+macro_rules! cryptoki_aligned {
+    ($decl:item) => {
+        #[cfg(windows)]
+        #[repr(packed, C)]
+        $decl
+        #[cfg(not(windows))]
+        #[repr(C)]
+        $decl
+    }
+}
+
 use std;
 use std::mem;
 use std::slice;
@@ -84,26 +96,28 @@ pub type CK_VOID_PTR_PTR = *const CK_VOID_PTR;
 /// handle or object handle
 pub const CK_INVALID_HANDLE: CK_ULONG = 0;
 
-#[derive(Debug, Copy, Default)]
-#[repr(packed, C)]
-pub struct CK_VERSION {
-  pub major: CK_BYTE, /* integer portion of version number */
-  pub minor: CK_BYTE, /* 1/100ths portion of version number */
+cryptoki_aligned! {
+  #[derive(Debug, Copy, Default)]
+  pub struct CK_VERSION {
+    pub major: CK_BYTE, /* integer portion of version number */
+    pub minor: CK_BYTE, /* 1/100ths portion of version number */
+  }
 }
 packed_clone!(CK_VERSION);
 
 pub type CK_VERSION_PTR = *const CK_VERSION;
 
-#[derive(Debug, Copy, Default)]
-#[repr(packed, C)]
-pub struct CK_INFO {
-  /* manufacturerID and libraryDecription have been changed from
-   * CK_CHAR to CK_UTF8CHAR for v2.10 */
-  pub cryptokiVersion: CK_VERSION,           /* Cryptoki interface ver */
-  pub manufacturerID: [CK_UTF8CHAR; 32],     /* blank padded */
-  pub flags: CK_FLAGS,                       /* must be zero */
-  pub libraryDescription: [CK_UTF8CHAR; 32], /* blank padded */
-  pub libraryVersion: CK_VERSION,            /* version of library */
+cryptoki_aligned! {
+  #[derive(Debug, Copy, Default)]
+  pub struct CK_INFO {
+    /* manufacturerID and libraryDecription have been changed from
+    * CK_CHAR to CK_UTF8CHAR for v2.10 */
+    pub cryptokiVersion: CK_VERSION,           /* Cryptoki interface ver */
+    pub manufacturerID: [CK_UTF8CHAR; 32],     /* blank padded */
+    pub flags: CK_FLAGS,                       /* must be zero */
+    pub libraryDescription: [CK_UTF8CHAR; 32], /* blank padded */
+    pub libraryVersion: CK_VERSION,            /* version of library */
+  }
 }
 packed_clone!(CK_INFO);
 
@@ -132,18 +146,19 @@ pub type CK_SLOT_ID = CK_ULONG;
 pub type CK_SLOT_ID_PTR = *const CK_SLOT_ID;
 
 /// CK_SLOT_INFO provides information about a slot
-#[repr(packed, C)]
-pub struct CK_SLOT_INFO {
-  /// slotDescription and manufacturerID have been changed from
-  /// CK_CHAR to CK_UTF8CHAR for v2.10
-  pub slotDescription: [CK_UTF8CHAR; 64], /* blank padded */
-  pub manufacturerID: [CK_UTF8CHAR; 32], /* blank padded */
-  pub flags: CK_FLAGS,
+cryptoki_aligned! {
+  pub struct CK_SLOT_INFO {
+    /// slotDescription and manufacturerID have been changed from
+    /// CK_CHAR to CK_UTF8CHAR for v2.10
+    pub slotDescription: [CK_UTF8CHAR; 64], /* blank padded */
+    pub manufacturerID: [CK_UTF8CHAR; 32], /* blank padded */
+    pub flags: CK_FLAGS,
 
-  /// version of hardware
-  pub hardwareVersion: CK_VERSION, /* version of hardware */
-  /// version of firmware
-  pub firmwareVersion: CK_VERSION, /* version of firmware */
+    /// version of hardware
+    pub hardwareVersion: CK_VERSION, /* version of hardware */
+    /// version of firmware
+    pub firmwareVersion: CK_VERSION, /* version of firmware */
+  }
 }
 
 impl Default for CK_SLOT_INFO {
@@ -183,29 +198,30 @@ pub const CKF_HW_SLOT: CK_FLAGS = 0x00000004;
 
 pub type CK_SLOT_INFO_PTR = *const CK_SLOT_INFO;
 
-#[derive(Debug, Copy)]
-#[repr(packed, C)]
-pub struct CK_TOKEN_INFO {
-  /* label, manufacturerID, and model have been changed from
-   * CK_CHAR to CK_UTF8CHAR for v2.10 */
-  pub label: [CK_UTF8CHAR; 32],          /* blank padded */
-  pub manufacturerID: [CK_UTF8CHAR; 32], /* blank padded */
-  pub model: [CK_UTF8CHAR; 16],          /* blank padded */
-  pub serialNumber: [CK_CHAR; 16],       /* blank padded */
-  pub flags: CK_FLAGS,                   /* see below */
-  pub ulMaxSessionCount: CK_ULONG,       /* max open sessions */
-  pub ulSessionCount: CK_ULONG,          /* sess. now open */
-  pub ulMaxRwSessionCount: CK_ULONG,     /* max R/W sessions */
-  pub ulRwSessionCount: CK_ULONG,        /* R/W sess. now open */
-  pub ulMaxPinLen: CK_ULONG,             /* in bytes */
-  pub ulMinPinLen: CK_ULONG,             /* in bytes */
-  pub ulTotalPublicMemory: CK_ULONG,     /* in bytes */
-  pub ulFreePublicMemory: CK_ULONG,      /* in bytes */
-  pub ulTotalPrivateMemory: CK_ULONG,    /* in bytes */
-  pub ulFreePrivateMemory: CK_ULONG,     /* in bytes */
-  pub hardwareVersion: CK_VERSION,       /* version of hardware */
-  pub firmwareVersion: CK_VERSION,       /* version of firmware */
-  pub utcTime: [CK_CHAR; 16],            /* time */
+cryptoki_aligned! {
+  #[derive(Debug, Copy)]
+  pub struct CK_TOKEN_INFO {
+    /* label, manufacturerID, and model have been changed from
+    * CK_CHAR to CK_UTF8CHAR for v2.10 */
+    pub label: [CK_UTF8CHAR; 32],          /* blank padded */
+    pub manufacturerID: [CK_UTF8CHAR; 32], /* blank padded */
+    pub model: [CK_UTF8CHAR; 16],          /* blank padded */
+    pub serialNumber: [CK_CHAR; 16],       /* blank padded */
+    pub flags: CK_FLAGS,                   /* see below */
+    pub ulMaxSessionCount: CK_ULONG,       /* max open sessions */
+    pub ulSessionCount: CK_ULONG,          /* sess. now open */
+    pub ulMaxRwSessionCount: CK_ULONG,     /* max R/W sessions */
+    pub ulRwSessionCount: CK_ULONG,        /* R/W sess. now open */
+    pub ulMaxPinLen: CK_ULONG,             /* in bytes */
+    pub ulMinPinLen: CK_ULONG,             /* in bytes */
+    pub ulTotalPublicMemory: CK_ULONG,     /* in bytes */
+    pub ulFreePublicMemory: CK_ULONG,      /* in bytes */
+    pub ulTotalPrivateMemory: CK_ULONG,    /* in bytes */
+    pub ulFreePrivateMemory: CK_ULONG,     /* in bytes */
+    pub hardwareVersion: CK_VERSION,       /* version of hardware */
+    pub firmwareVersion: CK_VERSION,       /* version of firmware */
+    pub utcTime: [CK_CHAR; 16],            /* time */
+  }
 }
 packed_clone!(CK_TOKEN_INFO);
 
@@ -347,14 +363,15 @@ pub const CKS_RW_PUBLIC_SESSION: CK_STATE = 2;
 pub const CKS_RW_USER_FUNCTIONS: CK_STATE = 3;
 pub const CKS_RW_SO_FUNCTIONS: CK_STATE = 4;
 
-#[derive(Debug, Default, Copy)]
-#[repr(packed, C)]
-pub struct CK_SESSION_INFO {
-  pub slotID: CK_SLOT_ID,
-  pub state: CK_STATE,
-  pub flags: CK_FLAGS,
-  /// device-dependent error code
-  pub ulDeviceError: CK_ULONG,
+cryptoki_aligned! {
+  #[derive(Debug, Default, Copy)]
+  pub struct CK_SESSION_INFO {
+    pub slotID: CK_SLOT_ID,
+    pub state: CK_STATE,
+    pub flags: CK_FLAGS,
+    /// device-dependent error code
+    pub ulDeviceError: CK_ULONG,
+  }
 }
 packed_clone!(CK_SESSION_INFO);
 
@@ -615,13 +632,14 @@ pub const CKA_VENDOR_DEFINED: CK_ATTRIBUTE_TYPE = 0x80000000;
 
 /// CK_ATTRIBUTE is a structure that includes the type, length
 /// and value of an attribute
-#[derive(Copy)]
-#[repr(packed, C)]
-pub struct CK_ATTRIBUTE {
-  pub attrType: CK_ATTRIBUTE_TYPE,
-  pub pValue: CK_VOID_PTR,
-  /// in bytes
-  pub ulValueLen: CK_ULONG,
+cryptoki_aligned! {
+  #[derive(Copy)]
+  pub struct CK_ATTRIBUTE {
+    pub attrType: CK_ATTRIBUTE_TYPE,
+    pub pValue: CK_VOID_PTR,
+    /// in bytes
+    pub ulValueLen: CK_ULONG,
+  }
 }
 packed_clone!(CK_ATTRIBUTE);
 
@@ -818,15 +836,16 @@ impl CK_ATTRIBUTE {
 //}
 
 /// CK_DATE is a structure that defines a date
-#[derive(Debug, Default, Copy)]
-#[repr(packed, C)]
-pub struct CK_DATE {
-  /// the year ("1900" - "9999")
-  pub year: [CK_CHAR; 4],
-  /// the month ("01" - "12")
-  pub month: [CK_CHAR; 2],
-  /// the day   ("01" - "31")
-  pub day: [CK_CHAR; 2],
+cryptoki_aligned! {
+  #[derive(Debug, Default, Copy)]
+  pub struct CK_DATE {
+    /// the year ("1900" - "9999")
+    pub year: [CK_CHAR; 4],
+    /// the month ("01" - "12")
+    pub month: [CK_CHAR; 2],
+    /// the day   ("01" - "31")
+    pub day: [CK_CHAR; 2],
+  }
 }
 packed_clone!(CK_DATE);
 
@@ -1233,13 +1252,14 @@ pub type CK_MECHANISM_TYPE_PTR = *const CK_MECHANISM_TYPE;
 
 /// CK_MECHANISM is a structure that specifies a particular
 /// mechanism
-#[derive(Debug, Copy)]
-#[repr(packed, C)]
-pub struct CK_MECHANISM {
-  pub mechanism: CK_MECHANISM_TYPE,
-  pub pParameter: CK_VOID_PTR,
-  /// in bytes
-  pub ulParameterLen: CK_ULONG,
+cryptoki_aligned! {
+  #[derive(Debug, Copy)]
+  pub struct CK_MECHANISM {
+    pub mechanism: CK_MECHANISM_TYPE,
+    pub pParameter: CK_VOID_PTR,
+    /// in bytes
+    pub ulParameterLen: CK_ULONG,
+  }
 }
 packed_clone!(CK_MECHANISM);
 
@@ -1247,12 +1267,13 @@ pub type CK_MECHANISM_PTR = *const CK_MECHANISM;
 
 /// CK_MECHANISM_INFO provides information about a particular
 /// mechanism
-#[derive(Debug, Default, Copy)]
-#[repr(packed, C)]
-pub struct CK_MECHANISM_INFO {
-  pub ulMinKeySize: CK_ULONG,
-  pub ulMaxKeySize: CK_ULONG,
-  pub flags: CK_FLAGS,
+cryptoki_aligned! {
+  #[derive(Debug, Default, Copy)]
+  pub struct CK_MECHANISM_INFO {
+    pub ulMinKeySize: CK_ULONG,
+    pub ulMaxKeySize: CK_ULONG,
+    pub flags: CK_FLAGS,
+  }
 }
 packed_clone!(CK_MECHANISM_INFO);
 
@@ -1391,78 +1412,79 @@ pub type CK_NOTIFY = Option<extern "C" fn(CK_SESSION_HANDLE, CK_NOTIFICATION, CK
 /// CK_FUNCTION_LIST is a structure holding a Cryptoki spec
 /// version and pointers of appropriate types to all the
 /// Cryptoki functions
-#[derive(Debug, Copy)]
-#[repr(packed, C)]
-pub struct CK_FUNCTION_LIST {
-  pub version: CK_VERSION,
-  pub C_Initialize: Option<C_Initialize>,
-  pub C_Finalize: Option<C_Finalize>,
-  pub C_GetInfo: Option<C_GetInfo>,
-  pub C_GetFunctionList: Option<C_GetFunctionList>,
-  pub C_GetSlotList: Option<C_GetSlotList>,
-  pub C_GetSlotInfo: Option<C_GetSlotInfo>,
-  pub C_GetTokenInfo: Option<C_GetTokenInfo>,
-  pub C_GetMechanismList: Option<C_GetMechanismList>,
-  pub C_GetMechanismInfo: Option<C_GetMechanismInfo>,
-  pub C_InitToken: Option<C_InitToken>,
-  pub C_InitPIN: Option<C_InitPIN>,
-  pub C_SetPIN: Option<C_SetPIN>,
-  pub C_OpenSession: Option<C_OpenSession>,
-  pub C_CloseSession: Option<C_CloseSession>,
-  pub C_CloseAllSessions: Option<C_CloseAllSessions>,
-  pub C_GetSessionInfo: Option<C_GetSessionInfo>,
-  pub C_GetOperationState: Option<C_GetOperationState>,
-  pub C_SetOperationState: Option<C_SetOperationState>,
-  pub C_Login: Option<C_Login>,
-  pub C_Logout: Option<C_Logout>,
-  pub C_CreateObject: Option<C_CreateObject>,
-  pub C_CopyObject: Option<C_CopyObject>,
-  pub C_DestroyObject: Option<C_DestroyObject>,
-  pub C_GetObjectSize: Option<C_GetObjectSize>,
-  pub C_GetAttributeValue: Option<C_GetAttributeValue>,
-  pub C_SetAttributeValue: Option<C_SetAttributeValue>,
-  pub C_FindObjectsInit: Option<C_FindObjectsInit>,
-  pub C_FindObjects: Option<C_FindObjects>,
-  pub C_FindObjectsFinal: Option<C_FindObjectsFinal>,
-  pub C_EncryptInit: Option<C_EncryptInit>,
-  pub C_Encrypt: Option<C_Encrypt>,
-  pub C_EncryptUpdate: Option<C_EncryptUpdate>,
-  pub C_EncryptFinal: Option<C_EncryptFinal>,
-  pub C_DecryptInit: Option<C_DecryptInit>,
-  pub C_Decrypt: Option<C_Decrypt>,
-  pub C_DecryptUpdate: Option<C_DecryptUpdate>,
-  pub C_DecryptFinal: Option<C_DecryptFinal>,
-  pub C_DigestInit: Option<C_DigestInit>,
-  pub C_Digest: Option<C_Digest>,
-  pub C_DigestUpdate: Option<C_DigestUpdate>,
-  pub C_DigestKey: Option<C_DigestKey>,
-  pub C_DigestFinal: Option<C_DigestFinal>,
-  pub C_SignInit: Option<C_SignInit>,
-  pub C_Sign: Option<C_Sign>,
-  pub C_SignUpdate: Option<C_SignUpdate>,
-  pub C_SignFinal: Option<C_SignFinal>,
-  pub C_SignRecoverInit: Option<C_SignRecoverInit>,
-  pub C_SignRecover: Option<C_SignRecover>,
-  pub C_VerifyInit: Option<C_VerifyInit>,
-  pub C_Verify: Option<C_Verify>,
-  pub C_VerifyUpdate: Option<C_VerifyUpdate>,
-  pub C_VerifyFinal: Option<C_VerifyFinal>,
-  pub C_VerifyRecoverInit: Option<C_VerifyRecoverInit>,
-  pub C_VerifyRecover: Option<C_VerifyRecover>,
-  pub C_DigestEncryptUpdate: Option<C_DigestEncryptUpdate>,
-  pub C_DecryptDigestUpdate: Option<C_DecryptDigestUpdate>,
-  pub C_SignEncryptUpdate: Option<C_SignEncryptUpdate>,
-  pub C_DecryptVerifyUpdate: Option<C_DecryptVerifyUpdate>,
-  pub C_GenerateKey: Option<C_GenerateKey>,
-  pub C_GenerateKeyPair: Option<C_GenerateKeyPair>,
-  pub C_WrapKey: Option<C_WrapKey>,
-  pub C_UnwrapKey: Option<C_UnwrapKey>,
-  pub C_DeriveKey: Option<C_DeriveKey>,
-  pub C_SeedRandom: Option<C_SeedRandom>,
-  pub C_GenerateRandom: Option<C_GenerateRandom>,
-  pub C_GetFunctionStatus: Option<C_GetFunctionStatus>,
-  pub C_CancelFunction: Option<C_CancelFunction>,
-  pub C_WaitForSlotEvent: Option<C_WaitForSlotEvent>,
+cryptoki_aligned! {
+  #[derive(Debug, Copy)]
+  pub struct CK_FUNCTION_LIST {
+    pub version: CK_VERSION,
+    pub C_Initialize: Option<C_Initialize>,
+    pub C_Finalize: Option<C_Finalize>,
+    pub C_GetInfo: Option<C_GetInfo>,
+    pub C_GetFunctionList: Option<C_GetFunctionList>,
+    pub C_GetSlotList: Option<C_GetSlotList>,
+    pub C_GetSlotInfo: Option<C_GetSlotInfo>,
+    pub C_GetTokenInfo: Option<C_GetTokenInfo>,
+    pub C_GetMechanismList: Option<C_GetMechanismList>,
+    pub C_GetMechanismInfo: Option<C_GetMechanismInfo>,
+    pub C_InitToken: Option<C_InitToken>,
+    pub C_InitPIN: Option<C_InitPIN>,
+    pub C_SetPIN: Option<C_SetPIN>,
+    pub C_OpenSession: Option<C_OpenSession>,
+    pub C_CloseSession: Option<C_CloseSession>,
+    pub C_CloseAllSessions: Option<C_CloseAllSessions>,
+    pub C_GetSessionInfo: Option<C_GetSessionInfo>,
+    pub C_GetOperationState: Option<C_GetOperationState>,
+    pub C_SetOperationState: Option<C_SetOperationState>,
+    pub C_Login: Option<C_Login>,
+    pub C_Logout: Option<C_Logout>,
+    pub C_CreateObject: Option<C_CreateObject>,
+    pub C_CopyObject: Option<C_CopyObject>,
+    pub C_DestroyObject: Option<C_DestroyObject>,
+    pub C_GetObjectSize: Option<C_GetObjectSize>,
+    pub C_GetAttributeValue: Option<C_GetAttributeValue>,
+    pub C_SetAttributeValue: Option<C_SetAttributeValue>,
+    pub C_FindObjectsInit: Option<C_FindObjectsInit>,
+    pub C_FindObjects: Option<C_FindObjects>,
+    pub C_FindObjectsFinal: Option<C_FindObjectsFinal>,
+    pub C_EncryptInit: Option<C_EncryptInit>,
+    pub C_Encrypt: Option<C_Encrypt>,
+    pub C_EncryptUpdate: Option<C_EncryptUpdate>,
+    pub C_EncryptFinal: Option<C_EncryptFinal>,
+    pub C_DecryptInit: Option<C_DecryptInit>,
+    pub C_Decrypt: Option<C_Decrypt>,
+    pub C_DecryptUpdate: Option<C_DecryptUpdate>,
+    pub C_DecryptFinal: Option<C_DecryptFinal>,
+    pub C_DigestInit: Option<C_DigestInit>,
+    pub C_Digest: Option<C_Digest>,
+    pub C_DigestUpdate: Option<C_DigestUpdate>,
+    pub C_DigestKey: Option<C_DigestKey>,
+    pub C_DigestFinal: Option<C_DigestFinal>,
+    pub C_SignInit: Option<C_SignInit>,
+    pub C_Sign: Option<C_Sign>,
+    pub C_SignUpdate: Option<C_SignUpdate>,
+    pub C_SignFinal: Option<C_SignFinal>,
+    pub C_SignRecoverInit: Option<C_SignRecoverInit>,
+    pub C_SignRecover: Option<C_SignRecover>,
+    pub C_VerifyInit: Option<C_VerifyInit>,
+    pub C_Verify: Option<C_Verify>,
+    pub C_VerifyUpdate: Option<C_VerifyUpdate>,
+    pub C_VerifyFinal: Option<C_VerifyFinal>,
+    pub C_VerifyRecoverInit: Option<C_VerifyRecoverInit>,
+    pub C_VerifyRecover: Option<C_VerifyRecover>,
+    pub C_DigestEncryptUpdate: Option<C_DigestEncryptUpdate>,
+    pub C_DecryptDigestUpdate: Option<C_DecryptDigestUpdate>,
+    pub C_SignEncryptUpdate: Option<C_SignEncryptUpdate>,
+    pub C_DecryptVerifyUpdate: Option<C_DecryptVerifyUpdate>,
+    pub C_GenerateKey: Option<C_GenerateKey>,
+    pub C_GenerateKeyPair: Option<C_GenerateKeyPair>,
+    pub C_WrapKey: Option<C_WrapKey>,
+    pub C_UnwrapKey: Option<C_UnwrapKey>,
+    pub C_DeriveKey: Option<C_DeriveKey>,
+    pub C_SeedRandom: Option<C_SeedRandom>,
+    pub C_GenerateRandom: Option<C_GenerateRandom>,
+    pub C_GetFunctionStatus: Option<C_GetFunctionStatus>,
+    pub C_CancelFunction: Option<C_CancelFunction>,
+    pub C_WaitForSlotEvent: Option<C_WaitForSlotEvent>,
+  }
 }
 packed_clone!(CK_FUNCTION_LIST);
 pub type CK_FUNCTION_LIST_PTR = *const CK_FUNCTION_LIST;
@@ -1482,15 +1504,16 @@ pub type CK_UNLOCKMUTEX = Option<extern "C" fn(CK_VOID_PTR) -> CK_RV>;
 
 /// CK_C_INITIALIZE_ARGS provides the optional arguments to
 /// C_Initialize
-#[derive(Debug, Copy)]
-#[repr(packed, C)]
-pub struct CK_C_INITIALIZE_ARGS {
-  pub CreateMutex: CK_CREATEMUTEX,
-  pub DestroyMutex: CK_DESTROYMUTEX,
-  pub LockMutex: CK_LOCKMUTEX,
-  pub UnlockMutex: CK_UNLOCKMUTEX,
-  pub flags: CK_FLAGS,
-  pub pReserved: CK_VOID_PTR,
+cryptoki_aligned! {
+  #[derive(Debug, Copy)]
+  pub struct CK_C_INITIALIZE_ARGS {
+    pub CreateMutex: CK_CREATEMUTEX,
+    pub DestroyMutex: CK_DESTROYMUTEX,
+    pub LockMutex: CK_LOCKMUTEX,
+    pub UnlockMutex: CK_UNLOCKMUTEX,
+    pub flags: CK_FLAGS,
+    pub pReserved: CK_VOID_PTR,
+  }
 }
 packed_clone!(CK_C_INITIALIZE_ARGS);
 
@@ -1544,14 +1567,15 @@ pub const CKZ_DATA_SPECIFIED: CK_RSA_PKCS_OAEP_SOURCE_TYPE = 0x00000001;
 
 /// CK_RSA_PKCS_OAEP_PARAMS provides the parameters to the
 /// CKM_RSA_PKCS_OAEP mechanism.
-#[derive(Debug, Copy)]
-#[repr(packed, C)]
-pub struct CK_RSA_PKCS_OAEP_PARAMS {
-  pub hashAlg: CK_MECHANISM_TYPE,
-  pub mgf: CK_RSA_PKCS_MGF_TYPE,
-  pub source: CK_RSA_PKCS_OAEP_SOURCE_TYPE,
-  pub pSourceData: CK_VOID_PTR,
-  pub ulSourceDataLen: CK_ULONG,
+cryptoki_aligned! {
+  #[derive(Debug, Copy)]
+  pub struct CK_RSA_PKCS_OAEP_PARAMS {
+    pub hashAlg: CK_MECHANISM_TYPE,
+    pub mgf: CK_RSA_PKCS_MGF_TYPE,
+    pub source: CK_RSA_PKCS_OAEP_SOURCE_TYPE,
+    pub pSourceData: CK_VOID_PTR,
+    pub ulSourceDataLen: CK_ULONG,
+  }
 }
 packed_clone!(CK_RSA_PKCS_OAEP_PARAMS);
 
@@ -1559,12 +1583,13 @@ pub type CK_RSA_PKCS_OAEP_PARAMS_PTR = *const CK_RSA_PKCS_OAEP_PARAMS;
 
 /// CK_RSA_PKCS_PSS_PARAMS provides the parameters to the
 /// CKM_RSA_PKCS_PSS mechanism(s).
-#[derive(Debug, Copy)]
-#[repr(packed, C)]
-pub struct CK_RSA_PKCS_PSS_PARAMS {
-  pub hashAlg: CK_MECHANISM_TYPE,
-  pub mgf: CK_RSA_PKCS_MGF_TYPE,
-  pub sLen: CK_ULONG,
+cryptoki_aligned! {
+  #[derive(Debug, Copy)]
+  pub struct CK_RSA_PKCS_PSS_PARAMS {
+    pub hashAlg: CK_MECHANISM_TYPE,
+    pub mgf: CK_RSA_PKCS_MGF_TYPE,
+    pub sLen: CK_ULONG,
+  }
 }
 packed_clone!(CK_RSA_PKCS_PSS_PARAMS);
 
@@ -1588,49 +1613,52 @@ pub const CKD_CPDIVERSIFY_KDF: CK_X9_42_DH_KDF_TYPE = 0x00000009;
 /// CK_ECDH1_DERIVE_PARAMS provides the parameters to the
 /// CKM_ECDH1_DERIVE and CKM_ECDH1_COFACTOR_DERIVE mechanisms,
 /// where each party contributes one key pair.
-#[repr(packed, C)]
-pub struct CK_ECDH1_DERIVE_PARAMS {
-  pub kdf: CK_EC_KDF_TYPE,
-  pub ulSharedDataLen: CK_ULONG,
-  pub pSharedData: CK_BYTE_PTR,
-  pub ulPublicDataLen: CK_ULONG,
-  pub pPublicData: CK_BYTE_PTR,
+cryptoki_aligned! {
+  pub struct CK_ECDH1_DERIVE_PARAMS {
+    pub kdf: CK_EC_KDF_TYPE,
+    pub ulSharedDataLen: CK_ULONG,
+    pub pSharedData: CK_BYTE_PTR,
+    pub ulPublicDataLen: CK_ULONG,
+    pub pPublicData: CK_BYTE_PTR,
+  }
 }
 
 pub type CK_ECDH1_DERIVE_PARAMS_PTR = *const CK_ECDH1_DERIVE_PARAMS;
 
 /// CK_ECDH2_DERIVE_PARAMS provides the parameters to the
 /// CKM_ECMQV_DERIVE mechanism, where each party contributes two key pairs.
-#[derive(Debug, Copy)]
-#[repr(packed, C)]
-pub struct CK_ECDH2_DERIVE_PARAMS {
-  pub kdf: CK_EC_KDF_TYPE,
-  pub ulSharedDataLen: CK_ULONG,
-  pub pSharedData: CK_BYTE_PTR,
-  pub ulPublicDataLen: CK_ULONG,
-  pub pPublicData: CK_BYTE_PTR,
-  pub ulPrivateDataLen: CK_ULONG,
-  pub hPrivateData: CK_OBJECT_HANDLE,
-  pub ulPublicDataLen2: CK_ULONG,
-  pub pPublicData2: CK_BYTE_PTR,
+cryptoki_aligned! {
+  #[derive(Debug, Copy)]
+  pub struct CK_ECDH2_DERIVE_PARAMS {
+    pub kdf: CK_EC_KDF_TYPE,
+    pub ulSharedDataLen: CK_ULONG,
+    pub pSharedData: CK_BYTE_PTR,
+    pub ulPublicDataLen: CK_ULONG,
+    pub pPublicData: CK_BYTE_PTR,
+    pub ulPrivateDataLen: CK_ULONG,
+    pub hPrivateData: CK_OBJECT_HANDLE,
+    pub ulPublicDataLen2: CK_ULONG,
+    pub pPublicData2: CK_BYTE_PTR,
+  }
 }
 packed_clone!(CK_ECDH2_DERIVE_PARAMS);
 
 pub type CK_ECDH2_DERIVE_PARAMS_PTR = *const CK_ECDH2_DERIVE_PARAMS;
 
-#[derive(Debug, Copy)]
-#[repr(packed, C)]
-pub struct CK_ECMQV_DERIVE_PARAMS {
-  pub kdf: CK_EC_KDF_TYPE,
-  pub ulSharedDataLen: CK_ULONG,
-  pub pSharedData: CK_BYTE_PTR,
-  pub ulPublicDataLen: CK_ULONG,
-  pub pPublicData: CK_BYTE_PTR,
-  pub ulPrivateDataLen: CK_ULONG,
-  pub hPrivateData: CK_OBJECT_HANDLE,
-  pub ulPublicDataLen2: CK_ULONG,
-  pub pPublicData2: CK_BYTE_PTR,
-  pub publicKey: CK_OBJECT_HANDLE,
+cryptoki_aligned! {
+  #[derive(Debug, Copy)]
+  pub struct CK_ECMQV_DERIVE_PARAMS {
+    pub kdf: CK_EC_KDF_TYPE,
+    pub ulSharedDataLen: CK_ULONG,
+    pub pSharedData: CK_BYTE_PTR,
+    pub ulPublicDataLen: CK_ULONG,
+    pub pPublicData: CK_BYTE_PTR,
+    pub ulPrivateDataLen: CK_ULONG,
+    pub hPrivateData: CK_OBJECT_HANDLE,
+    pub ulPublicDataLen2: CK_ULONG,
+    pub pPublicData2: CK_BYTE_PTR,
+    pub publicKey: CK_OBJECT_HANDLE,
+  }
 }
 packed_clone!(CK_ECMQV_DERIVE_PARAMS);
 
@@ -1644,14 +1672,15 @@ pub type CK_X9_42_DH_KDF_TYPE_PTR = *const CK_X9_42_DH_KDF_TYPE;
 /// CK_X9_42_DH1_DERIVE_PARAMS provides the parameters to the
 /// CKM_X9_42_DH_DERIVE key derivation mechanism, where each party
 /// contributes one key pair
-#[derive(Debug, Copy)]
-#[repr(packed, C)]
-pub struct CK_X9_42_DH1_DERIVE_PARAMS {
-  pub kdf: CK_X9_42_DH_KDF_TYPE,
-  pub ulOtherInfoLen: CK_ULONG,
-  pub pOtherInfo: CK_BYTE_PTR,
-  pub ulPublicDataLen: CK_ULONG,
-  pub pPublicData: CK_BYTE_PTR,
+cryptoki_aligned! {
+  #[derive(Debug, Copy)]
+  pub struct CK_X9_42_DH1_DERIVE_PARAMS {
+    pub kdf: CK_X9_42_DH_KDF_TYPE,
+    pub ulOtherInfoLen: CK_ULONG,
+    pub pOtherInfo: CK_BYTE_PTR,
+    pub ulPublicDataLen: CK_ULONG,
+    pub pPublicData: CK_BYTE_PTR,
+  }
 }
 packed_clone!(CK_X9_42_DH1_DERIVE_PARAMS);
 
@@ -1660,36 +1689,38 @@ pub type CK_X9_42_DH1_DERIVE_PARAMS_PTR = *const CK_X9_42_DH1_DERIVE_PARAMS;
 /// CK_X9_42_DH2_DERIVE_PARAMS provides the parameters to the
 /// CKM_X9_42_DH_HYBRID_DERIVE and CKM_X9_42_MQV_DERIVE key derivation
 /// mechanisms, where each party contributes two key pairs
-#[derive(Debug, Copy)]
-#[repr(packed, C)]
-pub struct CK_X9_42_DH2_DERIVE_PARAMS {
-  pub kdf: CK_X9_42_DH_KDF_TYPE,
-  pub ulOtherInfoLen: CK_ULONG,
-  pub pOtherInfo: CK_BYTE_PTR,
-  pub ulPublicDataLen: CK_ULONG,
-  pub pPublicData: CK_BYTE_PTR,
-  pub ulPrivateDataLen: CK_ULONG,
-  pub hPrivateData: CK_OBJECT_HANDLE,
-  pub ulPublicDataLen2: CK_ULONG,
-  pub pPublicData2: CK_BYTE_PTR,
+cryptoki_aligned! {
+  #[derive(Debug, Copy)]
+  pub struct CK_X9_42_DH2_DERIVE_PARAMS {
+    pub kdf: CK_X9_42_DH_KDF_TYPE,
+    pub ulOtherInfoLen: CK_ULONG,
+    pub pOtherInfo: CK_BYTE_PTR,
+    pub ulPublicDataLen: CK_ULONG,
+    pub pPublicData: CK_BYTE_PTR,
+    pub ulPrivateDataLen: CK_ULONG,
+    pub hPrivateData: CK_OBJECT_HANDLE,
+    pub ulPublicDataLen2: CK_ULONG,
+    pub pPublicData2: CK_BYTE_PTR,
+  }
 }
 packed_clone!(CK_X9_42_DH2_DERIVE_PARAMS);
 
 pub type CK_X9_42_DH2_DERIVE_PARAMS_PTR = *const CK_X9_42_DH2_DERIVE_PARAMS;
 
-#[derive(Debug, Copy)]
-#[repr(packed, C)]
-pub struct CK_X9_42_MQV_DERIVE_PARAMS {
-  pub kdf: CK_X9_42_DH_KDF_TYPE,
-  pub ulOtherInfoLen: CK_ULONG,
-  pub pOtherInfo: CK_BYTE_PTR,
-  pub ulPublicDataLen: CK_ULONG,
-  pub pPublicData: CK_BYTE_PTR,
-  pub ulPrivateDataLen: CK_ULONG,
-  pub hPrivateData: CK_OBJECT_HANDLE,
-  pub ulPublicDataLen2: CK_ULONG,
-  pub pPublicData2: CK_BYTE_PTR,
-  pub publicKey: CK_OBJECT_HANDLE,
+cryptoki_aligned! {
+  #[derive(Debug, Copy)]
+  pub struct CK_X9_42_MQV_DERIVE_PARAMS {
+    pub kdf: CK_X9_42_DH_KDF_TYPE,
+    pub ulOtherInfoLen: CK_ULONG,
+    pub pOtherInfo: CK_BYTE_PTR,
+    pub ulPublicDataLen: CK_ULONG,
+    pub pPublicData: CK_BYTE_PTR,
+    pub ulPrivateDataLen: CK_ULONG,
+    pub hPrivateData: CK_OBJECT_HANDLE,
+    pub ulPublicDataLen2: CK_ULONG,
+    pub pPublicData2: CK_BYTE_PTR,
+    pub publicKey: CK_OBJECT_HANDLE,
+  }
 }
 packed_clone!(CK_X9_42_MQV_DERIVE_PARAMS);
 
@@ -1697,15 +1728,16 @@ pub type CK_X9_42_MQV_DERIVE_PARAMS_PTR = *const CK_X9_42_MQV_DERIVE_PARAMS;
 
 /// CK_KEA_DERIVE_PARAMS provides the parameters to the
 /// CKM_KEA_DERIVE mechanism
-#[derive(Debug, Copy)]
-#[repr(packed, C)]
-pub struct CK_KEA_DERIVE_PARAMS {
-  pub isSender: CK_BBOOL,
-  pub ulRandomLen: CK_ULONG,
-  pub pRandomA: CK_BYTE_PTR,
-  pub pRandomB: CK_BYTE_PTR,
-  pub ulPublicDataLen: CK_ULONG,
-  pub pPublicData: CK_BYTE_PTR,
+cryptoki_aligned! {
+  #[derive(Debug, Copy)]
+  pub struct CK_KEA_DERIVE_PARAMS {
+    pub isSender: CK_BBOOL,
+    pub ulRandomLen: CK_ULONG,
+    pub pRandomA: CK_BYTE_PTR,
+    pub pRandomB: CK_BYTE_PTR,
+    pub ulPublicDataLen: CK_ULONG,
+    pub pPublicData: CK_BYTE_PTR,
+  }
 }
 packed_clone!(CK_KEA_DERIVE_PARAMS);
 
@@ -1721,13 +1753,14 @@ pub type CK_RC2_PARAMS_PTR = *const CK_RC2_PARAMS;
 
 /// CK_RC2_CBC_PARAMS provides the parameters to the CKM_RC2_CBC
 /// mechanism
-#[derive(Debug, Copy)]
-#[repr(packed, C)]
-pub struct CK_RC2_CBC_PARAMS {
-  /// effective bits (1-1024)
-  pub ulEffectiveBits: CK_ULONG,
-  /// IV for CBC mode
-  pub iv: [CK_BYTE; 8],
+cryptoki_aligned! {
+  #[derive(Debug, Copy)]
+  pub struct CK_RC2_CBC_PARAMS {
+    /// effective bits (1-1024)
+    pub ulEffectiveBits: CK_ULONG,
+    /// IV for CBC mode
+    pub iv: [CK_BYTE; 8],
+  }
 }
 packed_clone!(CK_RC2_CBC_PARAMS);
 
@@ -1736,13 +1769,14 @@ pub type CK_RC2_CBC_PARAMS_PTR = *const CK_RC2_CBC_PARAMS;
 
 /// CK_RC2_MAC_GENERAL_PARAMS provides the parameters for the
 /// CKM_RC2_MAC_GENERAL mechanism
-#[derive(Debug, Copy)]
-#[repr(packed, C)]
-pub struct CK_RC2_MAC_GENERAL_PARAMS {
-  /// effective bits (1-1024)
-  pub ulEffectiveBits: CK_ULONG,
-  /// Length of MAC in bytes
-  pub ulMacLength: CK_ULONG,
+cryptoki_aligned! {
+  #[derive(Debug, Copy)]
+  pub struct CK_RC2_MAC_GENERAL_PARAMS {
+    /// effective bits (1-1024)
+    pub ulEffectiveBits: CK_ULONG,
+    /// Length of MAC in bytes
+    pub ulMacLength: CK_ULONG,
+  }
 }
 packed_clone!(CK_RC2_MAC_GENERAL_PARAMS);
 
@@ -1751,13 +1785,14 @@ pub type CK_RC2_MAC_GENERAL_PARAMS_PTR = *const CK_RC2_MAC_GENERAL_PARAMS;
 
 /// CK_RC5_PARAMS provides the parameters to the CKM_RC5_ECB and
 /// CKM_RC5_MAC mechanisms
-#[derive(Debug, Copy)]
-#[repr(packed, C)]
-pub struct CK_RC5_PARAMS {
-  /// wordsize in bits
-  pub ulWordsize: CK_ULONG,
-  /// number of rounds
-  pub ulRounds: CK_ULONG,
+cryptoki_aligned! {
+  #[derive(Debug, Copy)]
+  pub struct CK_RC5_PARAMS {
+    /// wordsize in bits
+    pub ulWordsize: CK_ULONG,
+    /// number of rounds
+    pub ulRounds: CK_ULONG,
+  }
 }
 packed_clone!(CK_RC5_PARAMS);
 
@@ -1766,17 +1801,18 @@ pub type CK_RC5_PARAMS_PTR = *const CK_RC5_PARAMS;
 
 /// CK_RC5_CBC_PARAMS provides the parameters to the CKM_RC5_CBC
 /// mechanism
-#[derive(Debug, Copy)]
-#[repr(packed, C)]
-pub struct CK_RC5_CBC_PARAMS {
-  /// wordsize in bits
-  pub ulWordsize: CK_ULONG,
-  /// number of rounds
-  pub ulRounds: CK_ULONG,
-  /// pointer to IV
-  pub pIv: CK_BYTE_PTR,
-  /// length of IV in bytes
-  pub ulIvLen: CK_ULONG,
+cryptoki_aligned! {
+  #[derive(Debug, Copy)]
+  pub struct CK_RC5_CBC_PARAMS {
+    /// wordsize in bits
+    pub ulWordsize: CK_ULONG,
+    /// number of rounds
+    pub ulRounds: CK_ULONG,
+    /// pointer to IV
+    pub pIv: CK_BYTE_PTR,
+    /// length of IV in bytes
+    pub ulIvLen: CK_ULONG,
+  }
 }
 packed_clone!(CK_RC5_CBC_PARAMS);
 
@@ -1785,15 +1821,16 @@ pub type CK_RC5_CBC_PARAMS_PTR = *const CK_RC5_CBC_PARAMS;
 
 /// CK_RC5_MAC_GENERAL_PARAMS provides the parameters for the
 /// CKM_RC5_MAC_GENERAL mechanism
-#[derive(Debug, Copy)]
-#[repr(packed, C)]
-pub struct CK_RC5_MAC_GENERAL_PARAMS {
-  /// wordsize in bits
-  pub ulWordsize: CK_ULONG,
-  /// number of rounds
-  pub ulRounds: CK_ULONG,
-  /// Length of MAC in bytes
-  pub ulMacLength: CK_ULONG,
+cryptoki_aligned! {
+  #[derive(Debug, Copy)]
+  pub struct CK_RC5_MAC_GENERAL_PARAMS {
+    /// wordsize in bits
+    pub ulWordsize: CK_ULONG,
+    /// number of rounds
+    pub ulRounds: CK_ULONG,
+    /// Length of MAC in bytes
+    pub ulMacLength: CK_ULONG,
+  }
 }
 packed_clone!(CK_RC5_MAC_GENERAL_PARAMS);
 
@@ -1806,23 +1843,25 @@ pub type CK_MAC_GENERAL_PARAMS = CK_ULONG;
 
 pub type CK_MAC_GENERAL_PARAMS_PTR = *const CK_MAC_GENERAL_PARAMS;
 
-#[derive(Debug, Copy)]
-#[repr(packed, C)]
-pub struct CK_DES_CBC_ENCRYPT_DATA_PARAMS {
-  pub iv: [CK_BYTE; 8],
-  pub pData: CK_BYTE_PTR,
-  pub length: CK_ULONG,
+cryptoki_aligned! {
+  #[derive(Debug, Copy)]
+  pub struct CK_DES_CBC_ENCRYPT_DATA_PARAMS {
+    pub iv: [CK_BYTE; 8],
+    pub pData: CK_BYTE_PTR,
+    pub length: CK_ULONG,
+  }
 }
 packed_clone!(CK_DES_CBC_ENCRYPT_DATA_PARAMS);
 
 pub type CK_DES_CBC_ENCRYPT_DATA_PARAMS_PTR = *const CK_DES_CBC_ENCRYPT_DATA_PARAMS;
 
-#[derive(Debug, Copy)]
-#[repr(packed, C)]
-pub struct CK_AES_CBC_ENCRYPT_DATA_PARAMS {
-  pub iv: [CK_BYTE; 16],
-  pub pData: CK_BYTE_PTR,
-  pub length: CK_ULONG,
+cryptoki_aligned! {
+  #[derive(Debug, Copy)]
+  pub struct CK_AES_CBC_ENCRYPT_DATA_PARAMS {
+    pub iv: [CK_BYTE; 16],
+    pub pData: CK_BYTE_PTR,
+    pub length: CK_ULONG,
+  }
 }
 packed_clone!(CK_AES_CBC_ENCRYPT_DATA_PARAMS);
 
@@ -1830,20 +1869,21 @@ pub type CK_AES_CBC_ENCRYPT_DATA_PARAMS_PTR = *const CK_AES_CBC_ENCRYPT_DATA_PAR
 
 /// CK_SKIPJACK_PRIVATE_WRAP_PARAMS provides the parameters to the
 /// CKM_SKIPJACK_PRIVATE_WRAP mechanism
-#[derive(Debug, Copy)]
-#[repr(packed, C)]
-pub struct CK_SKIPJACK_PRIVATE_WRAP_PARAMS {
-  pub ulPasswordLen: CK_ULONG,
-  pub pPassword: CK_BYTE_PTR,
-  pub ulPublicDataLen: CK_ULONG,
-  pub pPublicData: CK_BYTE_PTR,
-  pub ulPAndGLen: CK_ULONG,
-  pub ulQLen: CK_ULONG,
-  pub ulRandomLen: CK_ULONG,
-  pub pRandomA: CK_BYTE_PTR,
-  pub pPrimeP: CK_BYTE_PTR,
-  pub pBaseG: CK_BYTE_PTR,
-  pub pSubprimeQ: CK_BYTE_PTR,
+cryptoki_aligned! {
+  #[derive(Debug, Copy)]
+  pub struct CK_SKIPJACK_PRIVATE_WRAP_PARAMS {
+    pub ulPasswordLen: CK_ULONG,
+    pub pPassword: CK_BYTE_PTR,
+    pub ulPublicDataLen: CK_ULONG,
+    pub pPublicData: CK_BYTE_PTR,
+    pub ulPAndGLen: CK_ULONG,
+    pub ulQLen: CK_ULONG,
+    pub ulRandomLen: CK_ULONG,
+    pub pRandomA: CK_BYTE_PTR,
+    pub pPrimeP: CK_BYTE_PTR,
+    pub pBaseG: CK_BYTE_PTR,
+    pub pSubprimeQ: CK_BYTE_PTR,
+  }
 }
 packed_clone!(CK_SKIPJACK_PRIVATE_WRAP_PARAMS);
 
@@ -1852,37 +1892,39 @@ pub type CK_SKIPJACK_PRIVATE_WRAP_PARAMS_PTR = *const CK_SKIPJACK_PRIVATE_WRAP_P
 
 /// CK_SKIPJACK_RELAYX_PARAMS provides the parameters to the
 /// CKM_SKIPJACK_RELAYX mechanism
-#[derive(Debug, Copy)]
-#[repr(packed, C)]
-pub struct CK_SKIPJACK_RELAYX_PARAMS {
-  pub ulOldWrappedXLen: CK_ULONG,
-  pub pOldWrappedX: CK_BYTE_PTR,
-  pub ulOldPasswordLen: CK_ULONG,
-  pub pOldPassword: CK_BYTE_PTR,
-  pub ulOldPublicDataLen: CK_ULONG,
-  pub pOldPublicData: CK_BYTE_PTR,
-  pub ulOldRandomLen: CK_ULONG,
-  pub pOldRandomA: CK_BYTE_PTR,
-  pub ulNewPasswordLen: CK_ULONG,
-  pub pNewPassword: CK_BYTE_PTR,
-  pub ulNewPublicDataLen: CK_ULONG,
-  pub pNewPublicData: CK_BYTE_PTR,
-  pub ulNewRandomLen: CK_ULONG,
-  pub pNewRandomA: CK_BYTE_PTR,
+cryptoki_aligned! {
+  #[derive(Debug, Copy)]
+  pub struct CK_SKIPJACK_RELAYX_PARAMS {
+    pub ulOldWrappedXLen: CK_ULONG,
+    pub pOldWrappedX: CK_BYTE_PTR,
+    pub ulOldPasswordLen: CK_ULONG,
+    pub pOldPassword: CK_BYTE_PTR,
+    pub ulOldPublicDataLen: CK_ULONG,
+    pub pOldPublicData: CK_BYTE_PTR,
+    pub ulOldRandomLen: CK_ULONG,
+    pub pOldRandomA: CK_BYTE_PTR,
+    pub ulNewPasswordLen: CK_ULONG,
+    pub pNewPassword: CK_BYTE_PTR,
+    pub ulNewPublicDataLen: CK_ULONG,
+    pub pNewPublicData: CK_BYTE_PTR,
+    pub ulNewRandomLen: CK_ULONG,
+    pub pNewRandomA: CK_BYTE_PTR,
+  }
 }
 packed_clone!(CK_SKIPJACK_RELAYX_PARAMS);
 
 pub type CK_SKIPJACK_RELAYX_PARAMS_PTR = *const CK_SKIPJACK_RELAYX_PARAMS;
 
-#[derive(Debug, Copy)]
-#[repr(packed, C)]
-pub struct CK_PBE_PARAMS {
-  pub pInitVector: CK_BYTE_PTR,
-  pub pPassword: CK_UTF8CHAR_PTR,
-  pub ulPasswordLen: CK_ULONG,
-  pub pSalt: CK_BYTE_PTR,
-  pub ulSaltLen: CK_ULONG,
-  pub ulIteration: CK_ULONG,
+cryptoki_aligned! {
+  #[derive(Debug, Copy)]
+  pub struct CK_PBE_PARAMS {
+    pub pInitVector: CK_BYTE_PTR,
+    pub pPassword: CK_UTF8CHAR_PTR,
+    pub ulPasswordLen: CK_ULONG,
+    pub pSalt: CK_BYTE_PTR,
+    pub ulSaltLen: CK_ULONG,
+    pub ulIteration: CK_ULONG,
+  }
 }
 packed_clone!(CK_PBE_PARAMS);
 
@@ -1891,168 +1933,181 @@ pub type CK_PBE_PARAMS_PTR = *const CK_PBE_PARAMS;
 
 /// CK_KEY_WRAP_SET_OAEP_PARAMS provides the parameters to the
 /// CKM_KEY_WRAP_SET_OAEP mechanism
-#[derive(Debug, Copy)]
-#[repr(packed, C)]
-pub struct CK_KEY_WRAP_SET_OAEP_PARAMS {
-  /// block contents byte
-  pub bBC: CK_BYTE,
-  /// extra data
-  pub pX: CK_BYTE_PTR,
-  /// length of extra data in bytes
-  pub ulXLen: CK_ULONG,
+cryptoki_aligned! {
+  #[derive(Debug, Copy)]
+  pub struct CK_KEY_WRAP_SET_OAEP_PARAMS {
+    /// block contents byte
+    pub bBC: CK_BYTE,
+    /// extra data
+    pub pX: CK_BYTE_PTR,
+    /// length of extra data in bytes
+    pub ulXLen: CK_ULONG,
+  }
 }
 packed_clone!(CK_KEY_WRAP_SET_OAEP_PARAMS);
 
 pub type CK_KEY_WRAP_SET_OAEP_PARAMS_PTR = *const CK_KEY_WRAP_SET_OAEP_PARAMS;
 
-#[derive(Debug, Copy)]
-#[repr(packed, C)]
-pub struct CK_SSL3_RANDOM_DATA {
-  pub pClientRandom: CK_BYTE_PTR,
-  pub ulClientRandomLen: CK_ULONG,
-  pub pServerRandom: CK_BYTE_PTR,
-  pub ulServerRandomLen: CK_ULONG,
+cryptoki_aligned! {
+  #[derive(Debug, Copy)]
+  pub struct CK_SSL3_RANDOM_DATA {
+    pub pClientRandom: CK_BYTE_PTR,
+    pub ulClientRandomLen: CK_ULONG,
+    pub pServerRandom: CK_BYTE_PTR,
+    pub ulServerRandomLen: CK_ULONG,
+  }
 }
 packed_clone!(CK_SSL3_RANDOM_DATA);
 
-#[derive(Debug, Copy)]
-#[repr(packed, C)]
-pub struct CK_SSL3_MASTER_KEY_DERIVE_PARAMS {
-  pub RandomInfo: CK_SSL3_RANDOM_DATA,
-  pub pVersion: CK_VERSION_PTR,
+cryptoki_aligned! {
+  #[derive(Debug, Copy)]
+  pub struct CK_SSL3_MASTER_KEY_DERIVE_PARAMS {
+    pub RandomInfo: CK_SSL3_RANDOM_DATA,
+    pub pVersion: CK_VERSION_PTR,
+  }
 }
 packed_clone!(CK_SSL3_MASTER_KEY_DERIVE_PARAMS);
 
 pub type CK_SSL3_MASTER_KEY_DERIVE_PARAMS_PTR = *const CK_SSL3_MASTER_KEY_DERIVE_PARAMS;
 
-#[derive(Debug, Copy)]
-#[repr(packed, C)]
-pub struct CK_SSL3_KEY_MAT_OUT {
-  pub hClientMacSecret: CK_OBJECT_HANDLE,
-  pub hServerMacSecret: CK_OBJECT_HANDLE,
-  pub hClientKey: CK_OBJECT_HANDLE,
-  pub hServerKey: CK_OBJECT_HANDLE,
-  pub pIVClient: CK_BYTE_PTR,
-  pub pIVServer: CK_BYTE_PTR,
+cryptoki_aligned! {
+  #[derive(Debug, Copy)]
+  pub struct CK_SSL3_KEY_MAT_OUT {
+    pub hClientMacSecret: CK_OBJECT_HANDLE,
+    pub hServerMacSecret: CK_OBJECT_HANDLE,
+    pub hClientKey: CK_OBJECT_HANDLE,
+    pub hServerKey: CK_OBJECT_HANDLE,
+    pub pIVClient: CK_BYTE_PTR,
+    pub pIVServer: CK_BYTE_PTR,
+  }
 }
 packed_clone!(CK_SSL3_KEY_MAT_OUT);
 
 pub type CK_SSL3_KEY_MAT_OUT_PTR = *const CK_SSL3_KEY_MAT_OUT;
 
-#[derive(Debug, Copy)]
-#[repr(packed, C)]
-pub struct CK_SSL3_KEY_MAT_PARAMS {
-  pub ulMacSizeInBits: CK_ULONG,
-  pub ulKeySizeInBits: CK_ULONG,
-  pub ulIVSizeInBits: CK_ULONG,
-  pub bIsExport: CK_BBOOL,
-  pub RandomInfo: CK_SSL3_RANDOM_DATA,
-  pub pReturnedKeyMaterial: CK_SSL3_KEY_MAT_OUT_PTR,
+cryptoki_aligned! {
+  #[derive(Debug, Copy)]
+  pub struct CK_SSL3_KEY_MAT_PARAMS {
+    pub ulMacSizeInBits: CK_ULONG,
+    pub ulKeySizeInBits: CK_ULONG,
+    pub ulIVSizeInBits: CK_ULONG,
+    pub bIsExport: CK_BBOOL,
+    pub RandomInfo: CK_SSL3_RANDOM_DATA,
+    pub pReturnedKeyMaterial: CK_SSL3_KEY_MAT_OUT_PTR,
+  }
 }
 packed_clone!(CK_SSL3_KEY_MAT_PARAMS);
 
 pub type CK_SSL3_KEY_MAT_PARAMS_PTR = *const CK_SSL3_KEY_MAT_PARAMS;
 
-#[derive(Debug, Copy)]
-#[repr(packed, C)]
-pub struct CK_TLS_PRF_PARAMS {
-  pub pSeed: CK_BYTE_PTR,
-  pub ulSeedLen: CK_ULONG,
-  pub pLabel: CK_BYTE_PTR,
-  pub ulLabelLen: CK_ULONG,
-  pub pOutput: CK_BYTE_PTR,
-  pub pulOutputLen: CK_ULONG_PTR,
+cryptoki_aligned! {
+  #[derive(Debug, Copy)]
+  pub struct CK_TLS_PRF_PARAMS {
+    pub pSeed: CK_BYTE_PTR,
+    pub ulSeedLen: CK_ULONG,
+    pub pLabel: CK_BYTE_PTR,
+    pub ulLabelLen: CK_ULONG,
+    pub pOutput: CK_BYTE_PTR,
+    pub pulOutputLen: CK_ULONG_PTR,
+  }
 }
 packed_clone!(CK_TLS_PRF_PARAMS);
 
 pub type CK_TLS_PRF_PARAMS_PTR = *const CK_TLS_PRF_PARAMS;
 
-#[derive(Debug, Copy)]
-#[repr(packed, C)]
-pub struct CK_WTLS_RANDOM_DATA {
-  pub pClientRandom: CK_BYTE_PTR,
-  pub ulClientRandomLen: CK_ULONG,
-  pub pServerRandom: CK_BYTE_PTR,
-  pub ulServerRandomLen: CK_ULONG,
+cryptoki_aligned! {
+  #[derive(Debug, Copy)]
+  pub struct CK_WTLS_RANDOM_DATA {
+    pub pClientRandom: CK_BYTE_PTR,
+    pub ulClientRandomLen: CK_ULONG,
+    pub pServerRandom: CK_BYTE_PTR,
+    pub ulServerRandomLen: CK_ULONG,
+  }
 }
 packed_clone!(CK_WTLS_RANDOM_DATA);
 
 pub type CK_WTLS_RANDOM_DATA_PTR = *const CK_WTLS_RANDOM_DATA;
 
-#[derive(Debug, Copy)]
-#[repr(packed, C)]
-pub struct CK_WTLS_MASTER_KEY_DERIVE_PARAMS {
-  pub DigestMechanism: CK_MECHANISM_TYPE,
-  pub RandomInfo: CK_WTLS_RANDOM_DATA,
-  pub pVersion: CK_BYTE_PTR,
+cryptoki_aligned! {
+  #[derive(Debug, Copy)]
+  pub struct CK_WTLS_MASTER_KEY_DERIVE_PARAMS {
+    pub DigestMechanism: CK_MECHANISM_TYPE,
+    pub RandomInfo: CK_WTLS_RANDOM_DATA,
+    pub pVersion: CK_BYTE_PTR,
+  }
 }
 packed_clone!(CK_WTLS_MASTER_KEY_DERIVE_PARAMS);
 
 pub type CK_WTLS_MASTER_KEY_DERIVE_PARAMS_PTR = *const CK_WTLS_MASTER_KEY_DERIVE_PARAMS;
 
-#[derive(Debug, Copy)]
-#[repr(packed, C)]
-pub struct CK_WTLS_PRF_PARAMS {
-  pub DigestMechanism: CK_MECHANISM_TYPE,
-  pub pSeed: CK_BYTE_PTR,
-  pub ulSeedLen: CK_ULONG,
-  pub pLabel: CK_BYTE_PTR,
-  pub ulLabelLen: CK_ULONG,
-  pub pOutput: CK_BYTE_PTR,
-  pub pulOutputLen: CK_ULONG_PTR,
+cryptoki_aligned! {
+  #[derive(Debug, Copy)]
+  pub struct CK_WTLS_PRF_PARAMS {
+    pub DigestMechanism: CK_MECHANISM_TYPE,
+    pub pSeed: CK_BYTE_PTR,
+    pub ulSeedLen: CK_ULONG,
+    pub pLabel: CK_BYTE_PTR,
+    pub ulLabelLen: CK_ULONG,
+    pub pOutput: CK_BYTE_PTR,
+    pub pulOutputLen: CK_ULONG_PTR,
+  }
 }
 packed_clone!(CK_WTLS_PRF_PARAMS);
 
 pub type CK_WTLS_PRF_PARAMS_PTR = *const CK_WTLS_PRF_PARAMS;
 
-#[derive(Debug, Copy)]
-#[repr(packed, C)]
-pub struct CK_WTLS_KEY_MAT_OUT {
-  pub hMacSecret: CK_OBJECT_HANDLE,
-  pub hKey: CK_OBJECT_HANDLE,
-  pub pIV: CK_BYTE_PTR,
+cryptoki_aligned! {
+  #[derive(Debug, Copy)]
+  pub struct CK_WTLS_KEY_MAT_OUT {
+    pub hMacSecret: CK_OBJECT_HANDLE,
+    pub hKey: CK_OBJECT_HANDLE,
+    pub pIV: CK_BYTE_PTR,
+  }
 }
 packed_clone!(CK_WTLS_KEY_MAT_OUT);
 
 pub type CK_WTLS_KEY_MAT_OUT_PTR = *const CK_WTLS_KEY_MAT_OUT;
 
-#[derive(Debug, Copy)]
-#[repr(packed, C)]
-pub struct CK_WTLS_KEY_MAT_PARAMS {
-  pub DigestMechanism: CK_MECHANISM_TYPE,
-  pub ulMacSizeInBits: CK_ULONG,
-  pub ulKeySizeInBits: CK_ULONG,
-  pub ulIVSizeInBits: CK_ULONG,
-  pub ulSequenceNumber: CK_ULONG,
-  pub bIsExport: CK_BBOOL,
-  pub RandomInfo: CK_WTLS_RANDOM_DATA,
-  pub pReturnedKeyMaterial: CK_WTLS_KEY_MAT_OUT_PTR,
+cryptoki_aligned! {
+  #[derive(Debug, Copy)]
+  pub struct CK_WTLS_KEY_MAT_PARAMS {
+    pub DigestMechanism: CK_MECHANISM_TYPE,
+    pub ulMacSizeInBits: CK_ULONG,
+    pub ulKeySizeInBits: CK_ULONG,
+    pub ulIVSizeInBits: CK_ULONG,
+    pub ulSequenceNumber: CK_ULONG,
+    pub bIsExport: CK_BBOOL,
+    pub RandomInfo: CK_WTLS_RANDOM_DATA,
+    pub pReturnedKeyMaterial: CK_WTLS_KEY_MAT_OUT_PTR,
+  }
 }
 packed_clone!(CK_WTLS_KEY_MAT_PARAMS);
 
 pub type CK_WTLS_KEY_MAT_PARAMS_PTR = *const CK_WTLS_KEY_MAT_PARAMS;
 
-#[derive(Debug, Copy)]
-#[repr(packed, C)]
-pub struct CK_CMS_SIG_PARAMS {
-  pub certificateHandle: CK_OBJECT_HANDLE,
-  pub pSigningMechanism: CK_MECHANISM_PTR,
-  pub pDigestMechanism: CK_MECHANISM_PTR,
-  pub pContentType: CK_UTF8CHAR_PTR,
-  pub pRequestedAttributes: CK_BYTE_PTR,
-  pub ulRequestedAttributesLen: CK_ULONG,
-  pub pRequiredAttributes: CK_BYTE_PTR,
-  pub ulRequiredAttributesLen: CK_ULONG,
+cryptoki_aligned! {
+  #[derive(Debug, Copy)]
+  pub struct CK_CMS_SIG_PARAMS {
+    pub certificateHandle: CK_OBJECT_HANDLE,
+    pub pSigningMechanism: CK_MECHANISM_PTR,
+    pub pDigestMechanism: CK_MECHANISM_PTR,
+    pub pContentType: CK_UTF8CHAR_PTR,
+    pub pRequestedAttributes: CK_BYTE_PTR,
+    pub ulRequestedAttributesLen: CK_ULONG,
+    pub pRequiredAttributes: CK_BYTE_PTR,
+    pub ulRequiredAttributesLen: CK_ULONG,
+  }
 }
 packed_clone!(CK_CMS_SIG_PARAMS);
 
 pub type CK_CMS_SIG_PARAMS_PTR = *const CK_CMS_SIG_PARAMS;
 
-#[derive(Debug, Copy)]
-#[repr(packed, C)]
-pub struct CK_KEY_DERIVATION_STRING_DATA {
-  pub pData: CK_BYTE_PTR,
-  pub ulLen: CK_ULONG,
+cryptoki_aligned! {
+  #[derive(Debug, Copy)]
+  pub struct CK_KEY_DERIVATION_STRING_DATA {
+    pub pData: CK_BYTE_PTR,
+    pub ulLen: CK_ULONG,
+  }
 }
 packed_clone!(CK_KEY_DERIVATION_STRING_DATA);
 
@@ -2095,18 +2150,19 @@ pub const CKZ_SALT_SPECIFIED: CK_PKCS5_PBKDF2_SALT_SOURCE_TYPE = 0x00000001;
 
 /// CK_PKCS5_PBKD2_PARAMS is a structure that provides the
 /// parameters to the CKM_PKCS5_PBKD2 mechanism.
-#[derive(Debug, Copy)]
-#[repr(packed, C)]
-pub struct CK_PKCS5_PBKD2_PARAMS {
-  pub saltSource: CK_PKCS5_PBKDF2_SALT_SOURCE_TYPE,
-  pub pSaltSourceData: CK_VOID_PTR,
-  pub ulSaltSourceDataLen: CK_ULONG,
-  pub iterations: CK_ULONG,
-  pub prf: CK_PKCS5_PBKD2_PSEUDO_RANDOM_FUNCTION_TYPE,
-  pub pPrfData: CK_VOID_PTR,
-  pub ulPrfDataLen: CK_ULONG,
-  pub pPassword: CK_UTF8CHAR_PTR,
-  pub ulPasswordLen: CK_ULONG_PTR,
+cryptoki_aligned! {
+  #[derive(Debug, Copy)]
+  pub struct CK_PKCS5_PBKD2_PARAMS {
+    pub saltSource: CK_PKCS5_PBKDF2_SALT_SOURCE_TYPE,
+    pub pSaltSourceData: CK_VOID_PTR,
+    pub ulSaltSourceDataLen: CK_ULONG,
+    pub iterations: CK_ULONG,
+    pub prf: CK_PKCS5_PBKD2_PSEUDO_RANDOM_FUNCTION_TYPE,
+    pub pPrfData: CK_VOID_PTR,
+    pub ulPrfDataLen: CK_ULONG,
+    pub pPassword: CK_UTF8CHAR_PTR,
+    pub ulPasswordLen: CK_ULONG_PTR,
+  }
 }
 packed_clone!(CK_PKCS5_PBKD2_PARAMS);
 
@@ -2115,18 +2171,19 @@ pub type CK_PKCS5_PBKD2_PARAMS_PTR = *const CK_PKCS5_PBKD2_PARAMS;
 /// CK_PKCS5_PBKD2_PARAMS2 is a corrected version of the CK_PKCS5_PBKD2_PARAMS
 /// structure that provides the parameters to the CKM_PKCS5_PBKD2 mechanism
 /// noting that the ulPasswordLen field is a CK_ULONG and not a CK_ULONG_PTR.
-#[derive(Debug, Copy)]
-#[repr(packed, C)]
-pub struct CK_PKCS5_PBKD2_PARAMS2 {
-  pub saltSource: CK_PKCS5_PBKDF2_SALT_SOURCE_TYPE,
-  pub pSaltSourceData: CK_VOID_PTR,
-  pub ulSaltSourceDataLen: CK_ULONG,
-  pub iterations: CK_ULONG,
-  pub prf: CK_PKCS5_PBKD2_PSEUDO_RANDOM_FUNCTION_TYPE,
-  pub pPrfData: CK_VOID_PTR,
-  pub ulPrfDataLen: CK_ULONG,
-  pub pPassword: CK_UTF8CHAR_PTR,
-  pub ulPasswordLen: CK_ULONG,
+cryptoki_aligned! {
+  #[derive(Debug, Copy)]
+  pub struct CK_PKCS5_PBKD2_PARAMS2 {
+    pub saltSource: CK_PKCS5_PBKDF2_SALT_SOURCE_TYPE,
+    pub pSaltSourceData: CK_VOID_PTR,
+    pub ulSaltSourceDataLen: CK_ULONG,
+    pub iterations: CK_ULONG,
+    pub prf: CK_PKCS5_PBKD2_PSEUDO_RANDOM_FUNCTION_TYPE,
+    pub pPrfData: CK_VOID_PTR,
+    pub ulPrfDataLen: CK_ULONG,
+    pub pPassword: CK_UTF8CHAR_PTR,
+    pub ulPasswordLen: CK_ULONG,
+  }
 }
 packed_clone!(CK_PKCS5_PBKD2_PARAMS2);
 
@@ -2136,32 +2193,35 @@ pub type CK_OTP_PARAM_TYPE = CK_ULONG;
 /// backward compatibility
 pub type CK_PARAM_TYPE = CK_OTP_PARAM_TYPE;
 
-#[derive(Debug, Copy)]
-#[repr(packed, C)]
-pub struct CK_OTP_PARAM {
-  pub paramType: CK_OTP_PARAM_TYPE,
-  pub pValue: CK_VOID_PTR,
-  pub ulValueLen: CK_ULONG,
+cryptoki_aligned! {
+  #[derive(Debug, Copy)]
+  pub struct CK_OTP_PARAM {
+    pub paramType: CK_OTP_PARAM_TYPE,
+    pub pValue: CK_VOID_PTR,
+    pub ulValueLen: CK_ULONG,
+  }
 }
 packed_clone!(CK_OTP_PARAM);
 
 pub type CK_OTP_PARAM_PTR = *const CK_OTP_PARAM;
 
-#[derive(Debug, Copy)]
-#[repr(packed, C)]
-pub struct CK_OTP_PARAMS {
-  pub pParams: CK_OTP_PARAM_PTR,
-  pub ulCount: CK_ULONG,
+cryptoki_aligned! {
+  #[derive(Debug, Copy)]
+  pub struct CK_OTP_PARAMS {
+    pub pParams: CK_OTP_PARAM_PTR,
+    pub ulCount: CK_ULONG,
+  }
 }
 packed_clone!(CK_OTP_PARAMS);
 
 pub type CK_OTP_PARAMS_PTR = *const CK_OTP_PARAMS;
 
-#[derive(Debug, Copy)]
-#[repr(packed, C)]
-pub struct CK_OTP_SIGNATURE_INFO {
-  pub pParams: CK_OTP_PARAM_PTR,
-  pub ulCount: CK_ULONG,
+cryptoki_aligned! {
+  #[derive(Debug, Copy)]
+  pub struct CK_OTP_SIGNATURE_INFO {
+    pub pParams: CK_OTP_PARAM_PTR,
+    pub ulCount: CK_ULONG,
+  }
 }
 packed_clone!(CK_OTP_SIGNATURE_INFO);
 
@@ -2183,137 +2243,148 @@ pub const CKF_EXCLUDE_CHALLENGE: CK_FLAGS = 0x00000008;
 pub const CKF_EXCLUDE_PIN: CK_FLAGS = 0x00000010;
 pub const CKF_USER_FRIENDLY_OTP: CK_FLAGS = 0x00000020;
 
-#[derive(Debug, Copy)]
-#[repr(packed, C)]
-pub struct CK_KIP_PARAMS {
-  pub pMechanism: CK_MECHANISM_PTR,
-  pub hKey: CK_OBJECT_HANDLE,
-  pub pSeed: CK_BYTE_PTR,
-  pub ulSeedLen: CK_ULONG,
+cryptoki_aligned! {
+  #[derive(Debug, Copy)]
+  pub struct CK_KIP_PARAMS {
+    pub pMechanism: CK_MECHANISM_PTR,
+    pub hKey: CK_OBJECT_HANDLE,
+    pub pSeed: CK_BYTE_PTR,
+    pub ulSeedLen: CK_ULONG,
+  }
 }
 packed_clone!(CK_KIP_PARAMS);
 
 pub type CK_KIP_PARAMS_PTR = *const CK_KIP_PARAMS;
 
-#[derive(Debug, Copy)]
-#[repr(packed, C)]
-pub struct CK_AES_CTR_PARAMS {
-  pub ulCounterBits: CK_ULONG,
-  pub cb: [CK_BYTE; 16],
+cryptoki_aligned! {
+  #[derive(Debug, Copy)]
+  pub struct CK_AES_CTR_PARAMS {
+    pub ulCounterBits: CK_ULONG,
+    pub cb: [CK_BYTE; 16],
+  }
 }
 packed_clone!(CK_AES_CTR_PARAMS);
 
 pub type CK_AES_CTR_PARAMS_PTR = *const CK_AES_CTR_PARAMS;
 
-#[derive(Debug, Copy)]
-#[repr(packed, C)]
-pub struct CK_GCM_PARAMS {
-  pub pIv: CK_BYTE_PTR,
-  pub ulIvLen: CK_ULONG,
-  pub ulIvBits: CK_ULONG,
-  pub pAAD: CK_BYTE_PTR,
-  pub ulAADLen: CK_ULONG,
-  pub ulTagBits: CK_ULONG,
+cryptoki_aligned! {
+  #[derive(Debug, Copy)]
+  pub struct CK_GCM_PARAMS {
+    pub pIv: CK_BYTE_PTR,
+    pub ulIvLen: CK_ULONG,
+    pub ulIvBits: CK_ULONG,
+    pub pAAD: CK_BYTE_PTR,
+    pub ulAADLen: CK_ULONG,
+    pub ulTagBits: CK_ULONG,
+  }
 }
 packed_clone!(CK_GCM_PARAMS);
 
 pub type CK_GCM_PARAMS_PTR = *const CK_GCM_PARAMS;
 
-#[derive(Debug, Copy)]
-#[repr(packed, C)]
-pub struct CK_CCM_PARAMS {
-  pub ulDataLen: CK_ULONG,
-  pub pNonce: CK_BYTE_PTR,
-  pub ulNonceLen: CK_ULONG,
-  pub pAAD: CK_BYTE_PTR,
-  pub ulAADLen: CK_ULONG,
-  pub ulMACLen: CK_ULONG,
+cryptoki_aligned! {
+  #[derive(Debug, Copy)]
+  pub struct CK_CCM_PARAMS {
+    pub ulDataLen: CK_ULONG,
+    pub pNonce: CK_BYTE_PTR,
+    pub ulNonceLen: CK_ULONG,
+    pub pAAD: CK_BYTE_PTR,
+    pub ulAADLen: CK_ULONG,
+    pub ulMACLen: CK_ULONG,
+  }
 }
 packed_clone!(CK_CCM_PARAMS);
 
 pub type CK_CCM_PARAMS_PTR = *const CK_CCM_PARAMS;
 
 /// Deprecated. Use CK_GCM_PARAMS
-#[derive(Debug, Copy)]
-#[repr(packed, C)]
-pub struct CK_AES_GCM_PARAMS {
-  pub pIv: CK_BYTE_PTR,
-  pub ulIvLen: CK_ULONG,
-  pub ulIvBits: CK_ULONG,
-  pub pAAD: CK_BYTE_PTR,
-  pub ulAADLen: CK_ULONG,
-  pub ulTagBits: CK_ULONG,
+cryptoki_aligned! {
+  #[derive(Debug, Copy)]
+  pub struct CK_AES_GCM_PARAMS {
+    pub pIv: CK_BYTE_PTR,
+    pub ulIvLen: CK_ULONG,
+    pub ulIvBits: CK_ULONG,
+    pub pAAD: CK_BYTE_PTR,
+    pub ulAADLen: CK_ULONG,
+    pub ulTagBits: CK_ULONG,
+  }
 }
 packed_clone!(CK_AES_GCM_PARAMS);
 
 pub type CK_AES_GCM_PARAMS_PTR = *const CK_AES_GCM_PARAMS;
 
 /// Deprecated. Use CK_CCM_PARAMS
-#[derive(Debug, Copy)]
-#[repr(packed, C)]
-pub struct CK_AES_CCM_PARAMS {
-  pub ulDataLen: CK_ULONG,
-  pub pNonce: CK_BYTE_PTR,
-  pub ulNonceLen: CK_ULONG,
-  pub pAAD: CK_BYTE_PTR,
-  pub ulAADLen: CK_ULONG,
-  pub ulMACLen: CK_ULONG,
+cryptoki_aligned! {
+  #[derive(Debug, Copy)]
+  pub struct CK_AES_CCM_PARAMS {
+    pub ulDataLen: CK_ULONG,
+    pub pNonce: CK_BYTE_PTR,
+    pub ulNonceLen: CK_ULONG,
+    pub pAAD: CK_BYTE_PTR,
+    pub ulAADLen: CK_ULONG,
+    pub ulMACLen: CK_ULONG,
+  }
 }
 packed_clone!(CK_AES_CCM_PARAMS);
 
 pub type CK_AES_CCM_PARAMS_PTR = *const CK_AES_CCM_PARAMS;
 
-#[derive(Debug, Copy)]
-#[repr(packed, C)]
-pub struct CK_CAMELLIA_CTR_PARAMS {
-  pub ulCounterBits: CK_ULONG,
-  pub cb: [CK_BYTE; 16],
+cryptoki_aligned! {
+  #[derive(Debug, Copy)]
+  pub struct CK_CAMELLIA_CTR_PARAMS {
+    pub ulCounterBits: CK_ULONG,
+    pub cb: [CK_BYTE; 16],
+  }
 }
 packed_clone!(CK_CAMELLIA_CTR_PARAMS);
 
 pub type CK_CAMELLIA_CTR_PARAMS_PTR = *const CK_CAMELLIA_CTR_PARAMS;
 
-#[derive(Debug, Copy)]
-#[repr(packed, C)]
-pub struct CK_CAMELLIA_CBC_ENCRYPT_DATA_PARAMS {
-  pub iv: [CK_BYTE; 16],
-  pub pData: CK_BYTE_PTR,
-  pub length: CK_ULONG,
+cryptoki_aligned! {
+  #[derive(Debug, Copy)]
+  pub struct CK_CAMELLIA_CBC_ENCRYPT_DATA_PARAMS {
+    pub iv: [CK_BYTE; 16],
+    pub pData: CK_BYTE_PTR,
+    pub length: CK_ULONG,
+  }
 }
 packed_clone!(CK_CAMELLIA_CBC_ENCRYPT_DATA_PARAMS);
 
 pub type CK_CAMELLIA_CBC_ENCRYPT_DATA_PARAMS_PTR = *const CK_CAMELLIA_CBC_ENCRYPT_DATA_PARAMS;
 
-#[derive(Debug, Copy)]
-#[repr(packed, C)]
-pub struct CK_ARIA_CBC_ENCRYPT_DATA_PARAMS {
-  pub iv: [CK_BYTE; 16],
-  pub pData: CK_BYTE_PTR,
-  pub length: CK_ULONG,
+cryptoki_aligned! {
+  #[derive(Debug, Copy)]
+  pub struct CK_ARIA_CBC_ENCRYPT_DATA_PARAMS {
+    pub iv: [CK_BYTE; 16],
+    pub pData: CK_BYTE_PTR,
+    pub length: CK_ULONG,
+  }
 }
 packed_clone!(CK_ARIA_CBC_ENCRYPT_DATA_PARAMS);
 
 pub type CK_ARIA_CBC_ENCRYPT_DATA_PARAMS_PTR = *const CK_ARIA_CBC_ENCRYPT_DATA_PARAMS;
 
-#[derive(Debug, Copy)]
-#[repr(packed, C)]
-pub struct CK_DSA_PARAMETER_GEN_PARAM {
-  pub hash: CK_MECHANISM_TYPE,
-  pub pSeed: CK_BYTE_PTR,
-  pub ulSeedLen: CK_ULONG,
-  pub ulIndex: CK_ULONG,
+cryptoki_aligned! {
+  #[derive(Debug, Copy)]
+  pub struct CK_DSA_PARAMETER_GEN_PARAM {
+    pub hash: CK_MECHANISM_TYPE,
+    pub pSeed: CK_BYTE_PTR,
+    pub ulSeedLen: CK_ULONG,
+    pub ulIndex: CK_ULONG,
+  }
 }
 packed_clone!(CK_DSA_PARAMETER_GEN_PARAM);
 
 pub type CK_DSA_PARAMETER_GEN_PARAM_PTR = *const CK_DSA_PARAMETER_GEN_PARAM;
 
-#[derive(Debug, Copy)]
-#[repr(packed, C)]
-pub struct CK_ECDH_AES_KEY_WRAP_PARAMS {
-  pub ulAESKeyBits: CK_ULONG,
-  pub kdf: CK_EC_KDF_TYPE,
-  pub ulSharedDataLen: CK_ULONG,
-  pub pSharedData: CK_BYTE_PTR,
+cryptoki_aligned! {
+  #[derive(Debug, Copy)]
+  pub struct CK_ECDH_AES_KEY_WRAP_PARAMS {
+    pub ulAESKeyBits: CK_ULONG,
+    pub kdf: CK_EC_KDF_TYPE,
+    pub ulSharedDataLen: CK_ULONG,
+    pub pSharedData: CK_BYTE_PTR,
+  }
 }
 packed_clone!(CK_ECDH_AES_KEY_WRAP_PARAMS);
 
@@ -2323,99 +2394,107 @@ pub type CK_JAVA_MIDP_SECURITY_DOMAIN = CK_ULONG;
 
 pub type CK_CERTIFICATE_CATEGORY = CK_ULONG;
 
-#[derive(Debug, Copy)]
-#[repr(packed, C)]
-pub struct CK_RSA_AES_KEY_WRAP_PARAMS {
-  pub ulAESKeyBits: CK_ULONG,
-  pub pOAEPParams: CK_RSA_PKCS_OAEP_PARAMS_PTR,
+cryptoki_aligned! {
+  #[derive(Debug, Copy)]
+  pub struct CK_RSA_AES_KEY_WRAP_PARAMS {
+    pub ulAESKeyBits: CK_ULONG,
+    pub pOAEPParams: CK_RSA_PKCS_OAEP_PARAMS_PTR,
+  }
 }
 packed_clone!(CK_RSA_AES_KEY_WRAP_PARAMS);
 
 pub type CK_RSA_AES_KEY_WRAP_PARAMS_PTR = *const CK_RSA_AES_KEY_WRAP_PARAMS;
 
-#[derive(Debug, Copy)]
-#[repr(packed, C)]
-pub struct CK_TLS12_MASTER_KEY_DERIVE_PARAMS {
-  pub RandomInfo: CK_SSL3_RANDOM_DATA,
-  pub pVersion: CK_VERSION_PTR,
-  pub prfHashMechanism: CK_MECHANISM_TYPE,
+cryptoki_aligned! {
+  #[derive(Debug, Copy)]
+  pub struct CK_TLS12_MASTER_KEY_DERIVE_PARAMS {
+    pub RandomInfo: CK_SSL3_RANDOM_DATA,
+    pub pVersion: CK_VERSION_PTR,
+    pub prfHashMechanism: CK_MECHANISM_TYPE,
+  }
 }
 packed_clone!(CK_TLS12_MASTER_KEY_DERIVE_PARAMS);
 
 pub type CK_TLS12_MASTER_KEY_DERIVE_PARAMS_PTR = *const CK_TLS12_MASTER_KEY_DERIVE_PARAMS;
 
-#[derive(Debug, Copy)]
-#[repr(packed, C)]
-pub struct CK_TLS12_KEY_MAT_PARAMS {
-  pub ulMacSizeInBits: CK_ULONG,
-  pub ulKeySizeInBits: CK_ULONG,
-  pub ulIVSizeInBits: CK_ULONG,
-  pub bIsExport: CK_BBOOL,
-  pub RandomInfo: CK_SSL3_RANDOM_DATA,
-  pub pReturnedKeyMaterial: CK_SSL3_KEY_MAT_OUT_PTR,
-  pub prfHashMechanism: CK_MECHANISM_TYPE,
+cryptoki_aligned! {
+  #[derive(Debug, Copy)]
+  pub struct CK_TLS12_KEY_MAT_PARAMS {
+    pub ulMacSizeInBits: CK_ULONG,
+    pub ulKeySizeInBits: CK_ULONG,
+    pub ulIVSizeInBits: CK_ULONG,
+    pub bIsExport: CK_BBOOL,
+    pub RandomInfo: CK_SSL3_RANDOM_DATA,
+    pub pReturnedKeyMaterial: CK_SSL3_KEY_MAT_OUT_PTR,
+    pub prfHashMechanism: CK_MECHANISM_TYPE,
+  }
 }
 packed_clone!(CK_TLS12_KEY_MAT_PARAMS);
 
 pub type CK_TLS12_KEY_MAT_PARAMS_PTR = *const CK_TLS12_KEY_MAT_PARAMS;
 
-#[derive(Debug, Copy)]
-#[repr(packed, C)]
-pub struct CK_TLS_KDF_PARAMS {
-  pub prfMechanism: CK_MECHANISM_TYPE,
-  pub pLabel: CK_BYTE_PTR,
-  pub ulLabelLength: CK_ULONG,
-  pub RandomInfo: CK_SSL3_RANDOM_DATA,
-  pub pContextData: CK_BYTE_PTR,
-  pub ulContextDataLength: CK_ULONG,
+cryptoki_aligned! {
+  #[derive(Debug, Copy)]
+  pub struct CK_TLS_KDF_PARAMS {
+    pub prfMechanism: CK_MECHANISM_TYPE,
+    pub pLabel: CK_BYTE_PTR,
+    pub ulLabelLength: CK_ULONG,
+    pub RandomInfo: CK_SSL3_RANDOM_DATA,
+    pub pContextData: CK_BYTE_PTR,
+    pub ulContextDataLength: CK_ULONG,
+  }
 }
 packed_clone!(CK_TLS_KDF_PARAMS);
 
 pub type CK_TLS_KDF_PARAMS_PTR = *const CK_TLS_KDF_PARAMS;
 
-#[derive(Debug, Copy)]
-#[repr(packed, C)]
-pub struct CK_TLS_MAC_PARAMS {
-  pub prfHashMechanism: CK_MECHANISM_TYPE,
-  pub ulMacLength: CK_ULONG,
-  pub ulServerOrClient: CK_ULONG,
+cryptoki_aligned! {
+  #[derive(Debug, Copy)]
+  pub struct CK_TLS_MAC_PARAMS {
+    pub prfHashMechanism: CK_MECHANISM_TYPE,
+    pub ulMacLength: CK_ULONG,
+    pub ulServerOrClient: CK_ULONG,
+  }
 }
 packed_clone!(CK_TLS_MAC_PARAMS);
 
 pub type CK_TLS_MAC_PARAMS_PTR = *const CK_TLS_MAC_PARAMS;
 
-#[derive(Debug, Copy)]
-#[repr(packed, C)]
-pub struct CK_GOSTR3410_DERIVE_PARAMS {
-  pub kdf: CK_EC_KDF_TYPE,
-  pub pPublicData: CK_BYTE_PTR,
-  pub ulPublicDataLen: CK_ULONG,
-  pub pUKM: CK_BYTE_PTR,
-  pub ulUKMLen: CK_ULONG,
+cryptoki_aligned! {
+  #[derive(Debug, Copy)]
+  pub struct CK_GOSTR3410_DERIVE_PARAMS {
+    pub kdf: CK_EC_KDF_TYPE,
+    pub pPublicData: CK_BYTE_PTR,
+    pub ulPublicDataLen: CK_ULONG,
+    pub pUKM: CK_BYTE_PTR,
+    pub ulUKMLen: CK_ULONG,
+  }
 }
 packed_clone!(CK_GOSTR3410_DERIVE_PARAMS);
 
 pub type CK_GOSTR3410_DERIVE_PARAMS_PTR = *const CK_GOSTR3410_DERIVE_PARAMS;
 
-#[derive(Debug, Copy)]
-#[repr(packed, C)]
-pub struct CK_GOSTR3410_KEY_WRAP_PARAMS {
-  pub pWrapOID: CK_BYTE_PTR,
-  pub ulWrapOIDLen: CK_ULONG,
-  pub pUKM: CK_BYTE_PTR,
-  pub ulUKMLen: CK_ULONG,
-  pub hKey: CK_OBJECT_HANDLE,
+cryptoki_aligned! {
+  #[derive(Debug, Copy)]
+  pub struct CK_GOSTR3410_KEY_WRAP_PARAMS {
+    pub pWrapOID: CK_BYTE_PTR,
+    pub ulWrapOIDLen: CK_ULONG,
+    pub pUKM: CK_BYTE_PTR,
+    pub ulUKMLen: CK_ULONG,
+    pub hKey: CK_OBJECT_HANDLE,
+  }
 }
 packed_clone!(CK_GOSTR3410_KEY_WRAP_PARAMS);
 
 pub type CK_GOSTR3410_KEY_WRAP_PARAMS_PTR = *const CK_GOSTR3410_KEY_WRAP_PARAMS;
 
-#[derive(Debug, Copy)]
-#[repr(packed, C)]
-pub struct CK_SEED_CBC_ENCRYPT_DATA_PARAMS {
-  pub iv: [CK_BYTE; 16],
-  pub pData: CK_BYTE_PTR,
-  pub length: CK_ULONG,
+cryptoki_aligned! {
+  #[derive(Debug, Copy)]
+  pub struct CK_SEED_CBC_ENCRYPT_DATA_PARAMS {
+    pub iv: [CK_BYTE; 16],
+    pub pData: CK_BYTE_PTR,
+    pub length: CK_ULONG,
+  }
 }
 packed_clone!(CK_SEED_CBC_ENCRYPT_DATA_PARAMS);
 


### PR DESCRIPTION
I'm hopeful this fixes #4, since this is the only major change made.

There's some macro shenanigans to make it work, but it works ok.