### PR TITLE
Add login_with_raw for raw PIN

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -546,6 +546,10 @@ impl Ctx {
     }
   }
 
+  // Some dongle drivers (such as Safenet) allow NUL bytes in PINs, and fail
+  // login if a NUL containing PIN is truncated. Combined with poor PIN gen
+  // algorithms which insert NULs into the PIN, you might need a way to supply
+  // raw bytes for a PIN, instead of converting from a UTF8 string as per spec
   pub fn login_with_raw<'a>(&self, session: CK_SESSION_HANDLE, user_type: CK_USER_TYPE, pin: Option<&Vec<CK_BYTE>>) -> Result<(), Error> {
     self.initialized()?;
     match pin {


### PR DESCRIPTION
I have some absolutely broken dongles that have a NUL byte in their PIN. Despite being completely against spec, this is totally accepted by my driver and they will *only* unlock with the NUL byte version of the PIN.

To make life easier, I've added a login that takes raw bytes in a Vec<CK_BYTE>.  I can see it being useful in cases where the PIN is difficult (or impossible in this case...) to coerce to/from UTF8