### PR TITLE
lib, types: Implement string accessors for some padded fields

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,15 @@ impl CkFrom<CK_BBOOL> for bool {
   }
 }
 
+fn str_from_blank_padded(field: &[CK_UTF8CHAR]) -> Result<&str, Error> {
+  let decoded_str = match std::str::from_utf8(field) {
+    Ok(decoded_str) => decoded_str,
+    Err(_) => return Err(Error::InvalidInput("field isn't UTF-8")),
+  };
+
+  Ok(decoded_str.trim_end_matches(' '))
+}
+
 fn label_from_str(label: &str) -> [CK_UTF8CHAR; 32] {
   // initialize a fixed-size array with whitespace characters
   let mut lab: [CK_UTF8CHAR; 32] = [32; 32];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,13 +64,9 @@ impl CkFrom<CK_BBOOL> for bool {
   }
 }
 
-fn str_from_blank_padded(field: &[CK_UTF8CHAR]) -> Result<&str, Error> {
-  let decoded_str = match std::str::from_utf8(field) {
-    Ok(decoded_str) => decoded_str,
-    Err(_) => return Err(Error::InvalidInput("field isn't UTF-8")),
-  };
-
-  Ok(decoded_str.trim_end_matches(' '))
+fn str_from_blank_padded(field: &[CK_UTF8CHAR]) -> String {
+  let decoded_str = String::from_utf8_lossy(field);
+  decoded_str.trim_end_matches(' ').to_string()
 }
 
 fn label_from_str(label: &str) -> [CK_UTF8CHAR; 32] {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -54,18 +54,18 @@ fn test_str_from_blank_padded() {
   let trailing_nonblanks_not_removed = b"only spaces removed\t\t\t\t";
   let invalid_utf8 = b"\xffinvalid";
 
-  assert_eq!(nothing_removed, str_from_blank_padded(nothing_removed).unwrap().as_bytes());
+  assert_eq!(nothing_removed, str_from_blank_padded(nothing_removed).as_bytes());
   assert_eq!(
-    b"a few removed", str_from_blank_padded(trailing_blanks_removed).unwrap().as_bytes());
+    b"a few removed", str_from_blank_padded(trailing_blanks_removed).as_bytes());
   assert_eq!(
     leading_blanks_not_removed,
-    str_from_blank_padded(leading_blanks_not_removed).unwrap().as_bytes());
+    str_from_blank_padded(leading_blanks_not_removed).as_bytes());
   assert_eq!(
     trailing_nonblanks_not_removed,
-    str_from_blank_padded(trailing_nonblanks_not_removed).unwrap().as_bytes());
+    str_from_blank_padded(trailing_nonblanks_not_removed).as_bytes());
   assert_eq!(
-    "PKCS#11 Invalid Input: field isn't UTF-8",
-    str_from_blank_padded(invalid_utf8).unwrap_err().to_string());
+    "�invalid",
+    str_from_blank_padded(invalid_utf8).to_string());
 }
 
 #[test]
@@ -754,7 +754,7 @@ fn ctx_get_attribute_value() {
     ];
     println!("Template: {:?}", template);
     {
-      let res = ctx.get_attribute_value(sh, oh, &mut template); 
+      let res = ctx.get_attribute_value(sh, oh, &mut template);
       if !res.is_ok() {
         // Doing this not as an assert so we can both unwrap_err with the mut template and re-borrow template
         let err = res.unwrap_err();
@@ -1602,7 +1602,7 @@ fn ctx_get_invalid_attribute_value() {
 
     println!("Template: {:?}", template);
 
-    let res = ctx.get_attribute_value(sh, oh, &mut template); 
+    let res = ctx.get_attribute_value(sh, oh, &mut template);
     if !res.is_ok() {
       // Doing this not as an assert so we can both unwrap_err with the mut template and re-borrow template
       let err = res.unwrap_err();

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -157,6 +157,9 @@ fn ctx_get_info() {
   );
   let info = res.unwrap();
   println!("{:?}", info);
+
+  assert_eq!("SoftHSM", String::from(info.manufacturerID));
+  assert_eq!("Implementation of PKCS11", String::from(info.libraryDescription));
 }
 
 #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -47,6 +47,29 @@ fn pkcs11_module_name() -> PathBuf {
 
 #[test]
 #[serial]
+fn test_str_from_blank_padded() {
+  let nothing_removed = b"no padding blanks to remove";
+  let trailing_blanks_removed = b"a few removed     ";
+  let leading_blanks_not_removed = b"     untouched";
+  let trailing_nonblanks_not_removed = b"only spaces removed\t\t\t\t";
+  let invalid_utf8 = b"\xffinvalid";
+
+  assert_eq!(nothing_removed, str_from_blank_padded(nothing_removed).unwrap().as_bytes());
+  assert_eq!(
+    b"a few removed", str_from_blank_padded(trailing_blanks_removed).unwrap().as_bytes());
+  assert_eq!(
+    leading_blanks_not_removed,
+    str_from_blank_padded(leading_blanks_not_removed).unwrap().as_bytes());
+  assert_eq!(
+    trailing_nonblanks_not_removed,
+    str_from_blank_padded(trailing_nonblanks_not_removed).unwrap().as_bytes());
+  assert_eq!(
+    "PKCS#11 Invalid Input: field isn't UTF-8",
+    str_from_blank_padded(invalid_utf8).unwrap_err().to_string());
+}
+
+#[test]
+#[serial]
 fn test_label_from_str() {
   let s30 = "Löwe 老虎 Léopar虎d虎aaa";
   let s32 = "Löwe 老虎 Léopar虎d虎aaaö";

--- a/src/types.rs
+++ b/src/types.rs
@@ -98,6 +98,11 @@ pub type CK_VOID_PTR_PTR = *mut CK_VOID_PTR;
 /// handle or object handle
 pub const CK_INVALID_HANDLE: CK_ULONG = 0;
 
+/* NOTE: The newtypes in this module are manual expansions of variants
+ * of [CK_UTF8CHAR; N].
+ * A future version of this library should replace these with PaddingStr<N>
+ * for const N, once Rust stablizes the constant generics feature.
+ */
 pub mod padding {
   use types::CK_UTF8CHAR;
   use ::str_from_blank_padded;

--- a/src/types.rs
+++ b/src/types.rs
@@ -139,11 +139,11 @@ impl CK_INFO {
     }
   }
 
-  pub fn manufacturer_id_str(&self) -> Result<&str, Error> {
+  pub fn manufacturer_id_str(&self) -> String {
     str_from_blank_padded(&self.manufacturerID)
   }
 
-  pub fn library_description_str(&self) -> Result<&str, Error> {
+  pub fn library_description_str(&self) -> String {
     str_from_blank_padded(&self.libraryDescription)
   }
 }
@@ -177,11 +177,11 @@ cryptoki_aligned! {
 }
 
 impl CK_SLOT_INFO {
-  pub fn slot_description_str(&self) -> Result<&str, Error> {
+  pub fn slot_description_str(&self) -> String {
     str_from_blank_padded(&self.slotDescription)
   }
 
-  pub fn manufacturer_id_str(&self) -> Result<&str, Error> {
+  pub fn manufacturer_id_str(&self) -> String {
     str_from_blank_padded(&self.manufacturerID)
   }
 }
@@ -249,19 +249,19 @@ cryptoki_aligned! {
 packed_clone!(CK_TOKEN_INFO);
 
 impl CK_TOKEN_INFO {
-  pub fn label_str(&self) -> Result<&str, Error> {
+  pub fn label_str(&self) -> String {
     str_from_blank_padded(&self.label)
   }
 
-  pub fn manufacturer_id_str(&self) -> Result<&str, Error> {
+  pub fn manufacturer_id_str(&self) -> String {
     str_from_blank_padded(&self.manufacturerID)
   }
 
-  pub fn model_str(&self) -> Result<&str, Error> {
+  pub fn model_str(&self) -> String {
     str_from_blank_padded(&self.model)
   }
 
-  pub fn serial_number_str(&self) -> Result<&str, Error> {
+  pub fn serial_number_str(&self) -> String {
     str_from_blank_padded(&self.serialNumber)
   }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -40,7 +40,7 @@ use num_bigint::BigUint;
 
 use errors::Error;
 use functions::*;
-use super::CkFrom;
+use super::{CkFrom, str_from_blank_padded};
 
 
 pub const CK_TRUE: CK_BBOOL = 1;
@@ -106,6 +106,12 @@ cryptoki_aligned! {
 }
 packed_clone!(CK_VERSION);
 
+impl std::fmt::Display for CK_VERSION {
+  fn fmt(&self, f: &mut std::fmt::Formatter<>) -> std::fmt::Result {
+      write!(f, "{}.{}", self.major, self.minor)
+  }
+}
+
 pub type CK_VERSION_PTR = *mut CK_VERSION;
 
 cryptoki_aligned! {
@@ -131,6 +137,14 @@ impl CK_INFO {
       libraryDescription: [32; 32],
       libraryVersion: Default::default(),
     }
+  }
+
+  pub fn manufacturer_id_str(&self) -> Result<&str, Error> {
+    str_from_blank_padded(&self.manufacturerID)
+  }
+
+  pub fn library_description_str(&self) -> Result<&str, Error> {
+    str_from_blank_padded(&self.libraryDescription)
   }
 }
 
@@ -159,6 +173,16 @@ cryptoki_aligned! {
     pub hardwareVersion: CK_VERSION, /* version of hardware */
     /// version of firmware
     pub firmwareVersion: CK_VERSION, /* version of firmware */
+  }
+}
+
+impl CK_SLOT_INFO {
+  pub fn slot_description_str(&self) -> Result<&str, Error> {
+    str_from_blank_padded(&self.slotDescription)
+  }
+
+  pub fn manufacturer_id_str(&self) -> Result<&str, Error> {
+    str_from_blank_padded(&self.manufacturerID)
   }
 }
 
@@ -223,6 +247,24 @@ cryptoki_aligned! {
   }
 }
 packed_clone!(CK_TOKEN_INFO);
+
+impl CK_TOKEN_INFO {
+  pub fn label_str(&self) -> Result<&str, Error> {
+    str_from_blank_padded(&self.label)
+  }
+
+  pub fn manufacturer_id_str(&self) -> Result<&str, Error> {
+    str_from_blank_padded(&self.manufacturerID)
+  }
+
+  pub fn model_str(&self) -> Result<&str, Error> {
+    str_from_blank_padded(&self.model)
+  }
+
+  pub fn serial_number_str(&self) -> Result<&str, Error> {
+    str_from_blank_padded(&self.serialNumber)
+  }
+}
 
 impl Default for CK_TOKEN_INFO {
   fn default() -> CK_TOKEN_INFO {


### PR DESCRIPTION
First of all, thanks a ton for your work on this! It's been invaluable.

This PR adds a library-private helper, `str_from_blank_padded`, and uses it to implement some convenience accessor functions for a few of the blank-padded fields in the PKCS#11 types. 

It also implements the `Display` trait for `CK_VERSION`, using the common `MAJOR.MINOR` format.

Please let me know if there's anything else I can do!