### PR TITLE
Finish unit/integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,15 +39,16 @@ Here is a list of the implementation status and plans on what to do next:
 - [x] Implementing Key Management functions
 - [x] Implementing Encryption/Decryption functions
 - [x] Implementing Message Digest functions
-- [x] Implementing Signing and MACing (TODO: tests still missing)
-- [x] Implementing Verifying of signatures and MACs (TODO: tests still missing)
-- [x] Implementing Dual-function cryptographic operations (TODO: tests still missing)
+- [x] Implementing Signing and MACing
+- [x] Implementing Verifying of signatures and MACs
+- [x] Implementing Dual-function cryptographic operations
 - [x] Implementing Legacy PKCS#11 functions
 - [x] Reorganize code of low-level API (too bloated, which we all know is what PKCS#11 is like)
 - [x] Import the rest of the C header `pkcs11t.h` types into rust
 - [x] Import the rest of the C header `pkcs11f.h` functions into rust
+- [x] Publish on crates.io (wow, that was easy)
 - [ ] C type constants to string converter functions, and the reverse (maybe part of the high-level API?)
 - [ ] Design and implement high-level API
-- [x] Publish on crates.io (wow, that was easy)
 - [ ] Write and Generate Documentation for Rust docs
 - [ ] Better Testing (lots of repetitive code + we need a testing framework and different SoftHSM versions for different platforms)
+- [ ] Suppport for PKCS#11 v3.00

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1840,13 +1840,14 @@ impl Ctx {
         }
     }
 
-    pub fn wait_for_slot_event(&self, flags: CK_FLAGS) -> Result<CK_SLOT_ID, Error> {
+    pub fn wait_for_slot_event(&self, flags: CK_FLAGS) -> Result<Option<CK_SLOT_ID>, Error> {
         let mut slotID: CK_SLOT_ID = 0;
         let C_WaitForSlotEvent = self
             .C_WaitForSlotEvent
             .ok_or(Error::Module("C_WaitForSlotEvent function not found"))?;
         match C_WaitForSlotEvent(flags, &mut slotID, ptr::null_mut()) {
-            CKR_OK => Ok(slotID),
+            CKR_OK => Ok(Some(slotID)),
+            CKR_NO_EVENT => Ok(None),
             err => Err(Error::Pkcs11(err)),
         }
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1723,7 +1723,7 @@ fn ctx_sign_recover_init() {
             Error::Pkcs11(CKR_FUNCTION_NOT_SUPPORTED) => {
                 println!("as expected SoftHSM does not support this function");
             }
-            _ => panic!("TODO: SoftHSM supports this function now, complete tests"),
+            _ => panic!("TODO: SoftHSM supports C_SignRecoverInit now, complete tests"),
         }
     } else {
         assert!(
@@ -1739,8 +1739,23 @@ fn ctx_sign_recover_init() {
 
 #[test]
 #[serial]
+fn ctx_sign_recover() {
+    let (ctx, sh) = fixture_token().unwrap();
+
+    let data = String::from("Lorem ipsum tralala").into_bytes();
+    let res = ctx.sign_recover(sh, &data);
+    assert!(res.is_err());
+    if let Error::Pkcs11(CKR_FUNCTION_NOT_SUPPORTED) = res.unwrap_err() {
+        println!("SoftHSM does not support C_SignRecover at the moment");
+        return;
+    }
+    panic!("TODO: SoftHSM supports C_SignRecover now, complete tests")
+}
+
+#[test]
+#[serial]
 fn ctx_verify_recover_init() {
-    let (ctx, sh, _, privOh) = fixture_token_and_key_pair().unwrap();
+    let (ctx, sh, pubOh, _) = fixture_token_and_key_pair().unwrap();
 
     let mechanism = CK_MECHANISM {
         mechanism: CKM_RSA_PKCS,
@@ -1748,7 +1763,7 @@ fn ctx_verify_recover_init() {
         ulParameterLen: 0,
     };
 
-    let res = ctx.verify_recover_init(sh, &mechanism, privOh);
+    let res = ctx.verify_recover_init(sh, &mechanism, pubOh);
     if res.is_err() {
         // SoftHSM does not support this function, so this is what we should compare against
         //assert_eq!(Error::Pkcs11(CKR_FUNCTION_NOT_SUPPORTED), res.unwrap_err());
@@ -1756,18 +1771,33 @@ fn ctx_verify_recover_init() {
             Error::Pkcs11(CKR_FUNCTION_NOT_SUPPORTED) => {
                 println!("as expected SoftHSM does not support this function");
             }
-            _ => panic!("TODO: SoftHSM supports this function now, complete tests"),
+            _ => panic!("TODO: SoftHSM supports C_VerifyRecoverInit now, complete tests"),
         }
     } else {
         assert!(
             res.is_ok(),
-            "failed to call C_SignRecoverInit({}, {:?}, {}) without parameter: {}",
+            "failed to call C_VerifyRecoverInit({}, {:?}, {}) without parameter: {}",
             sh,
             &mechanism,
-            privOh,
+            pubOh,
             res.unwrap_err()
         );
     }
+}
+
+#[test]
+#[serial]
+fn ctx_verify_recover() {
+    let (ctx, sh) = fixture_token().unwrap();
+
+    let data = String::from("Lorem ipsum tralala").into_bytes();
+    let res = ctx.verify_recover(sh, &data);
+    assert!(res.is_err());
+    if let Error::Pkcs11(CKR_FUNCTION_NOT_SUPPORTED) = res.unwrap_err() {
+        println!("SoftHSM does not support C_VerifyRecover at the moment");
+        return;
+    }
+    panic!("TODO: SoftHSM supports C_VerifyRecover now, complete tests")
 }
 
 #[test]
@@ -2783,7 +2813,7 @@ fn ctx_decrypt_digest_update() {
     let decryptedPlaintext1 = decryptedPlaintext1.unwrap();
     let decryptedPlaintext1 = String::from_utf8_lossy(&decryptedPlaintext1);
 
-    let decryptedPlaintext2 = ctx.digest_encrypt_update(sh, &ciphertext2);
+    let decryptedPlaintext2 = ctx.decrypt_digest_update(sh, &ciphertext2);
     assert!(
         decryptedPlaintext2.is_ok(),
         "failed to call C_DecryptDigestUpdate({}, {:?}): {}",
@@ -2814,6 +2844,40 @@ fn ctx_decrypt_digest_update() {
 
     assert_eq!(decryptedPlaintext1.as_ref(), plaintext1Str);
     assert_eq!(decryptedPlaintext2.as_ref(), plaintext2Str);
+}
+
+#[test]
+#[serial]
+fn ctx_sign_encrypt_update() {
+    let (ctx, sh, _, _) = fixture_token_and_key_pair().unwrap();
+
+    let data = String::from("Lorem ipsum tralala").into_bytes();
+
+    // check if this function is supported first
+    let res = ctx.sign_encrypt_update(sh, &data);
+    assert!(res.is_err());
+    if let Error::Pkcs11(CKR_FUNCTION_NOT_SUPPORTED) = res.unwrap_err() {
+        println!("SoftHSM does not support C_SignEncryptUpdate at the moment");
+        return;
+    }
+    panic!("TODO: SoftHSM supports C_SignEncryptUpdate now, complete tests")
+}
+
+#[test]
+#[serial]
+fn ctx_decrypt_verify_update() {
+    let (ctx, sh, _, _) = fixture_token_and_key_pair().unwrap();
+
+    let data = String::from("Lorem ipsum tralala").into_bytes();
+
+    // check if this function is supported first
+    let res = ctx.decrypt_verify_update(sh, data);
+    assert!(res.is_err());
+    if let Error::Pkcs11(CKR_FUNCTION_NOT_SUPPORTED) = res.unwrap_err() {
+        println!("SoftHSM does not support C_DecryptVerifyUpdate at the moment");
+        return;
+    }
+    panic!("TODO: SoftHSM supports C_DecryptVerifyUpdate now, complete tests")
 }
 
 #[test]


### PR DESCRIPTION
- adding stubs for sign recover and verify recover init as they are currently not supported by SoftHSM
- added stubs for all dual-mode functions for the same reasons
- implemented wait for slot event as this is now supported
- slightly changed the signature of wait for slot event