### PR TITLE
types: Fix CK_LONG/CK_ULONG on Linux ARM32

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -71,7 +71,7 @@ pub type CK_ULONG = u32;
 #[cfg(all(target_os = "linux", target_arch = "arm"))]
 pub type CK_ULONG = u32;
 
-#[cfg(not(windows))]
+#[cfg(all(not(windows), not(all(target_os = "linux", target_arch = "arm"))))]
 pub type CK_ULONG = u64;
 
 pub type CK_ULONG_PTR = *mut CK_ULONG;
@@ -83,7 +83,7 @@ pub type CK_LONG = i32;
 #[cfg(all(target_os = "linux", target_arch = "arm"))]
 pub type CK_LONG = i32;
 
-#[cfg(not(windows))]
+#[cfg(all(not(windows), not(all(target_os = "linux", target_arch = "arm"))))]
 pub type CK_LONG = i64;
 
 /// at least 32 bits; each bit is a Boolean flag

--- a/src/types.rs
+++ b/src/types.rs
@@ -67,13 +67,22 @@ pub type CK_BBOOL = CK_BYTE;
 /// an unsigned value, at least 32 bits long
 #[cfg(windows)]
 pub type CK_ULONG = u32;
+
+#[cfg(all(target_os = "linux", target_arch = "arm"))]
+pub type CK_ULONG = u32;
+
 #[cfg(not(windows))]
 pub type CK_ULONG = u64;
+
 pub type CK_ULONG_PTR = *mut CK_ULONG;
 
 /// a signed value, the same size as a CK_ULONG
 #[cfg(windows)]
 pub type CK_LONG = i32;
+
+#[cfg(all(target_os = "linux", target_arch = "arm"))]
+pub type CK_LONG = i32;
+
 #[cfg(not(windows))]
 pub type CK_LONG = i64;
 


### PR DESCRIPTION
This fixes an ABI mismatch that I observed experimentally when trying to use `rust-pkcs11` with a Nitrokey on a 32-bit ARM host (really 64-bit, but it's a Raspberry Pi running 32-bit Raspbian).

There are probably other ABI mismatches on other target OSes and architectures; a more general fix here might be to use `pkcs11t.h` directly via `bindgen` or some other mechanism.