### PR TITLE
errors: Stringify vendor-specific errors correctly

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -173,6 +173,6 @@ fn strerror(err: CK_RV) -> &'static str {
             } else {
                 "unknown"
             }
-        },
+        }
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -167,6 +167,12 @@ fn strerror(err: CK_RV) -> &'static str {
         CKR_PUBLIC_KEY_INVALID => "CKR_PUBLIC_KEY_INVALID",
         CKR_FUNCTION_REJECTED => "CKR_FUNCTION_REJECTED",
         CKR_VENDOR_DEFINED => "CKR_VENDOR_DEFINED",
-        _ => "unknown",
+        _ => {
+            if err > CKR_VENDOR_DEFINED {
+                "CKR_VENDOR_DEFINED"
+            } else {
+                "unknown"
+            }
+        },
     }
 }


### PR DESCRIPTION
PKCS11 says that `CKR_VENDOR_DEFINED` and above are always
vendor specific, so any `err` value above that range should also
be stringified as vendor specific, rather than "unknown".