### PR TITLE
✨ Requires functions optionally, supporting partial implementations

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -42,7 +42,7 @@ pub enum Error {
     UnavailableInformation,
 
     /// This error happens when trying to use the function which is not supported in the PKCS#11 API.
-    UnavailableFunction(String),
+    UnavailableFunction(&'static str),
 }
 
 impl From<libloading::Error> for Error {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -40,6 +40,9 @@ pub enum Error {
     /// and one tries to return the value of a `types::CK_ATTRIBUTE` with one of its associated
     /// getter method (e.g. `get_bytes`).
     UnavailableInformation,
+
+    /// This error happens when trying to use the function which is not supported in the PKCS#11 API.
+    UnavailableFunction(String),
 }
 
 impl From<libloading::Error> for Error {
@@ -56,6 +59,7 @@ impl std::fmt::Display for Error {
             Error::InvalidInput(ref err) => write!(f, "PKCS#11 Invalid Input: {}", err),
             Error::Pkcs11(ref err) => write!(f, "PKCS#11: {} (0x{:x})", strerror(*err), err),
             Error::UnavailableInformation => write!(f, "Attribute value is unavailable"),
+            Error::UnavailableFunction(ref name) => write!(f, "Function not available: {}", name),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,75 +91,93 @@ pub struct Ctx {
     lib: libloading::Library,
     _is_initialized: bool,
     version: CK_VERSION,
-    C_Initialize: C_Initialize,
-    C_Finalize: C_Finalize,
-    C_GetInfo: C_GetInfo,
-    C_GetFunctionList: C_GetFunctionList,
-    C_GetSlotList: C_GetSlotList,
-    C_GetSlotInfo: C_GetSlotInfo,
-    C_GetTokenInfo: C_GetTokenInfo,
-    C_GetMechanismList: C_GetMechanismList,
-    C_GetMechanismInfo: C_GetMechanismInfo,
-    C_InitToken: C_InitToken,
-    C_InitPIN: C_InitPIN,
-    C_SetPIN: C_SetPIN,
-    C_OpenSession: C_OpenSession,
-    C_CloseSession: C_CloseSession,
-    C_CloseAllSessions: C_CloseAllSessions,
-    C_GetSessionInfo: C_GetSessionInfo,
-    C_GetOperationState: C_GetOperationState,
-    C_SetOperationState: C_SetOperationState,
-    C_Login: C_Login,
-    C_Logout: C_Logout,
-    C_CreateObject: C_CreateObject,
-    C_CopyObject: C_CopyObject,
-    C_DestroyObject: C_DestroyObject,
-    C_GetObjectSize: C_GetObjectSize,
-    C_GetAttributeValue: C_GetAttributeValue,
-    C_SetAttributeValue: C_SetAttributeValue,
-    C_FindObjectsInit: C_FindObjectsInit,
-    C_FindObjects: C_FindObjects,
-    C_FindObjectsFinal: C_FindObjectsFinal,
-    C_EncryptInit: C_EncryptInit,
-    C_Encrypt: C_Encrypt,
-    C_EncryptUpdate: C_EncryptUpdate,
-    C_EncryptFinal: C_EncryptFinal,
-    C_DecryptInit: C_DecryptInit,
-    C_Decrypt: C_Decrypt,
-    C_DecryptUpdate: C_DecryptUpdate,
-    C_DecryptFinal: C_DecryptFinal,
-    C_DigestInit: C_DigestInit,
-    C_Digest: C_Digest,
-    C_DigestUpdate: C_DigestUpdate,
-    C_DigestKey: C_DigestKey,
-    C_DigestFinal: C_DigestFinal,
-    C_SignInit: C_SignInit,
-    C_Sign: C_Sign,
-    C_SignUpdate: C_SignUpdate,
-    C_SignFinal: C_SignFinal,
-    C_SignRecoverInit: C_SignRecoverInit,
-    C_SignRecover: C_SignRecover,
-    C_VerifyInit: C_VerifyInit,
-    C_Verify: C_Verify,
-    C_VerifyUpdate: C_VerifyUpdate,
-    C_VerifyFinal: C_VerifyFinal,
-    C_VerifyRecoverInit: C_VerifyRecoverInit,
-    C_VerifyRecover: C_VerifyRecover,
-    C_DigestEncryptUpdate: C_DigestEncryptUpdate,
-    C_DecryptDigestUpdate: C_DecryptDigestUpdate,
-    C_SignEncryptUpdate: C_SignEncryptUpdate,
-    C_DecryptVerifyUpdate: C_DecryptVerifyUpdate,
-    C_GenerateKey: C_GenerateKey,
-    C_GenerateKeyPair: C_GenerateKeyPair,
-    C_WrapKey: C_WrapKey,
-    C_UnwrapKey: C_UnwrapKey,
-    C_DeriveKey: C_DeriveKey,
-    C_SeedRandom: C_SeedRandom,
-    C_GenerateRandom: C_GenerateRandom,
-    C_GetFunctionStatus: C_GetFunctionStatus,
-    C_CancelFunction: C_CancelFunction,
+    C_Initialize: MaybeFn<C_Initialize>,
+    C_Finalize: MaybeFn<C_Finalize>,
+    C_GetInfo: MaybeFn<C_GetInfo>,
+    C_GetFunctionList: MaybeFn<C_GetFunctionList>,
+    C_GetSlotList: MaybeFn<C_GetSlotList>,
+    C_GetSlotInfo: MaybeFn<C_GetSlotInfo>,
+    C_GetTokenInfo: MaybeFn<C_GetTokenInfo>,
+    C_GetMechanismList: MaybeFn<C_GetMechanismList>,
+    C_GetMechanismInfo: MaybeFn<C_GetMechanismInfo>,
+    C_InitToken: MaybeFn<C_InitToken>,
+    C_InitPIN: MaybeFn<C_InitPIN>,
+    C_SetPIN: MaybeFn<C_SetPIN>,
+    C_OpenSession: MaybeFn<C_OpenSession>,
+    C_CloseSession: MaybeFn<C_CloseSession>,
+    C_CloseAllSessions: MaybeFn<C_CloseAllSessions>,
+    C_GetSessionInfo: MaybeFn<C_GetSessionInfo>,
+    C_GetOperationState: MaybeFn<C_GetOperationState>,
+    C_SetOperationState: MaybeFn<C_SetOperationState>,
+    C_Login: MaybeFn<C_Login>,
+    C_Logout: MaybeFn<C_Logout>,
+    C_CreateObject: MaybeFn<C_CreateObject>,
+    C_CopyObject: MaybeFn<C_CopyObject>,
+    C_DestroyObject: MaybeFn<C_DestroyObject>,
+    C_GetObjectSize: MaybeFn<C_GetObjectSize>,
+    C_GetAttributeValue: MaybeFn<C_GetAttributeValue>,
+    C_SetAttributeValue: MaybeFn<C_SetAttributeValue>,
+    C_FindObjectsInit: MaybeFn<C_FindObjectsInit>,
+    C_FindObjects: MaybeFn<C_FindObjects>,
+    C_FindObjectsFinal: MaybeFn<C_FindObjectsFinal>,
+    C_EncryptInit: MaybeFn<C_EncryptInit>,
+    C_Encrypt: MaybeFn<C_Encrypt>,
+    C_EncryptUpdate: MaybeFn<C_EncryptUpdate>,
+    C_EncryptFinal: MaybeFn<C_EncryptFinal>,
+    C_DecryptInit: MaybeFn<C_DecryptInit>,
+    C_Decrypt: MaybeFn<C_Decrypt>,
+    C_DecryptUpdate: MaybeFn<C_DecryptUpdate>,
+    C_DecryptFinal: MaybeFn<C_DecryptFinal>,
+    C_DigestInit: MaybeFn<C_DigestInit>,
+    C_Digest: MaybeFn<C_Digest>,
+    C_DigestUpdate: MaybeFn<C_DigestUpdate>,
+    C_DigestKey: MaybeFn<C_DigestKey>,
+    C_DigestFinal: MaybeFn<C_DigestFinal>,
+    C_SignInit: MaybeFn<C_SignInit>,
+    C_Sign: MaybeFn<C_Sign>,
+    C_SignUpdate: MaybeFn<C_SignUpdate>,
+    C_SignFinal: MaybeFn<C_SignFinal>,
+    C_SignRecoverInit: MaybeFn<C_SignRecoverInit>,
+    C_SignRecover: MaybeFn<C_SignRecover>,
+    C_VerifyInit: MaybeFn<C_VerifyInit>,
+    C_Verify: MaybeFn<C_Verify>,
+    C_VerifyUpdate: MaybeFn<C_VerifyUpdate>,
+    C_VerifyFinal: MaybeFn<C_VerifyFinal>,
+    C_VerifyRecoverInit: MaybeFn<C_VerifyRecoverInit>,
+    C_VerifyRecover: MaybeFn<C_VerifyRecover>,
+    C_DigestEncryptUpdate: MaybeFn<C_DigestEncryptUpdate>,
+    C_DecryptDigestUpdate: MaybeFn<C_DecryptDigestUpdate>,
+    C_SignEncryptUpdate: MaybeFn<C_SignEncryptUpdate>,
+    C_DecryptVerifyUpdate: MaybeFn<C_DecryptVerifyUpdate>,
+    C_GenerateKey: MaybeFn<C_GenerateKey>,
+    C_GenerateKeyPair: MaybeFn<C_GenerateKeyPair>,
+    C_WrapKey: MaybeFn<C_WrapKey>,
+    C_UnwrapKey: MaybeFn<C_UnwrapKey>,
+    C_DeriveKey: MaybeFn<C_DeriveKey>,
+    C_SeedRandom: MaybeFn<C_SeedRandom>,
+    C_GenerateRandom: MaybeFn<C_GenerateRandom>,
+    C_GetFunctionStatus: MaybeFn<C_GetFunctionStatus>,
+    C_CancelFunction: MaybeFn<C_CancelFunction>,
     // Functions added in for Cryptoki Version 2.01 or later
-    C_WaitForSlotEvent: Option<C_WaitForSlotEvent>,
+    C_WaitForSlotEvent: MaybeFn<C_WaitForSlotEvent>,
+}
+
+#[derive(Debug)]
+struct MaybeFn<T> {
+    func: Option<T>,
+}
+
+impl<T> MaybeFn<T> {
+    fn new(func: Option<T>) -> Self {
+        Self { func }
+    }
+
+    fn req(&self) -> Result<&T, Error> {
+        self.func.as_ref().ok_or(Error::UnavailableFunction(format!(
+            "{}",
+            std::any::type_name::<T>()
+        )))
+    }
 }
 
 impl Ctx {
@@ -186,211 +204,77 @@ impl Ctx {
                 lib,
                 _is_initialized: false,
                 version: (*list_ptr).version,
-                C_Initialize: (*list_ptr)
-                    .C_Initialize
-                    .ok_or(Error::Module("C_Initialize function not found"))?,
-                C_Finalize: (*list_ptr)
-                    .C_Finalize
-                    .ok_or(Error::Module("C_Finalize function not found"))?,
-                C_GetInfo: (*list_ptr)
-                    .C_GetInfo
-                    .ok_or(Error::Module("C_GetInfo function not found"))?,
-                C_GetFunctionList: (*list_ptr)
-                    .C_GetFunctionList
-                    .ok_or(Error::Module("C_GetFunctionList function not found"))?,
-                C_GetSlotList: (*list_ptr)
-                    .C_GetSlotList
-                    .ok_or(Error::Module("C_GetSlotList function not found"))?,
-                C_GetSlotInfo: (*list_ptr)
-                    .C_GetSlotInfo
-                    .ok_or(Error::Module("C_GetSlotInfo function not found"))?,
-                C_GetTokenInfo: (*list_ptr)
-                    .C_GetTokenInfo
-                    .ok_or(Error::Module("C_GetTokenInfo function not found"))?,
-                C_GetMechanismList: (*list_ptr)
-                    .C_GetMechanismList
-                    .ok_or(Error::Module("C_GetMechanismList function not found"))?,
-                C_GetMechanismInfo: (*list_ptr)
-                    .C_GetMechanismInfo
-                    .ok_or(Error::Module("C_GetMechanismInfo function not found"))?,
-                C_InitToken: (*list_ptr)
-                    .C_InitToken
-                    .ok_or(Error::Module("C_InitToken function not found"))?,
-                C_InitPIN: (*list_ptr)
-                    .C_InitPIN
-                    .ok_or(Error::Module("C_InitPIN function not found"))?,
-                C_SetPIN: (*list_ptr)
-                    .C_SetPIN
-                    .ok_or(Error::Module("C_SetPIN function not found"))?,
-                C_OpenSession: (*list_ptr)
-                    .C_OpenSession
-                    .ok_or(Error::Module("C_OpenSession function not found"))?,
-                C_CloseSession: (*list_ptr)
-                    .C_CloseSession
-                    .ok_or(Error::Module("C_CloseSession function not found"))?,
-                C_CloseAllSessions: (*list_ptr)
-                    .C_CloseAllSessions
-                    .ok_or(Error::Module("C_CloseAllSessions function not found"))?,
-                C_GetSessionInfo: (*list_ptr)
-                    .C_GetSessionInfo
-                    .ok_or(Error::Module("C_GetSessionInfo function not found"))?,
-                C_GetOperationState: (*list_ptr)
-                    .C_GetOperationState
-                    .ok_or(Error::Module("C_GetOperationState function not found"))?,
-                C_SetOperationState: (*list_ptr)
-                    .C_SetOperationState
-                    .ok_or(Error::Module("C_SetOperationState function not found"))?,
-                C_Login: (*list_ptr)
-                    .C_Login
-                    .ok_or(Error::Module("C_Login function not found"))?,
-                C_Logout: (*list_ptr)
-                    .C_Logout
-                    .ok_or(Error::Module("C_Logout function not found"))?,
-                C_CreateObject: (*list_ptr)
-                    .C_CreateObject
-                    .ok_or(Error::Module("C_CreateObject function not found"))?,
-                C_CopyObject: (*list_ptr)
-                    .C_CopyObject
-                    .ok_or(Error::Module("C_CopyObject function not found"))?,
-                C_DestroyObject: (*list_ptr)
-                    .C_DestroyObject
-                    .ok_or(Error::Module("C_DestroyObject function not found"))?,
-                C_GetObjectSize: (*list_ptr)
-                    .C_GetObjectSize
-                    .ok_or(Error::Module("C_GetObjectSize function not found"))?,
-                C_GetAttributeValue: (*list_ptr)
-                    .C_GetAttributeValue
-                    .ok_or(Error::Module("C_GetAttributeValue function not found"))?,
-                C_SetAttributeValue: (*list_ptr)
-                    .C_SetAttributeValue
-                    .ok_or(Error::Module("C_SetAttributeValue function not found"))?,
-                C_FindObjectsInit: (*list_ptr)
-                    .C_FindObjectsInit
-                    .ok_or(Error::Module("C_FindObjectsInit function not found"))?,
-                C_FindObjects: (*list_ptr)
-                    .C_FindObjects
-                    .ok_or(Error::Module("C_FindObjects function not found"))?,
-                C_FindObjectsFinal: (*list_ptr)
-                    .C_FindObjectsFinal
-                    .ok_or(Error::Module("C_FindObjectsFinal function not found"))?,
-                C_EncryptInit: (*list_ptr)
-                    .C_EncryptInit
-                    .ok_or(Error::Module("C_EncryptInit function not found"))?,
-                C_Encrypt: (*list_ptr)
-                    .C_Encrypt
-                    .ok_or(Error::Module("C_Encrypt function not found"))?,
-                C_EncryptUpdate: (*list_ptr)
-                    .C_EncryptUpdate
-                    .ok_or(Error::Module("C_EncryptUpdate function not found"))?,
-                C_EncryptFinal: (*list_ptr)
-                    .C_EncryptFinal
-                    .ok_or(Error::Module("C_EncryptFinal function not found"))?,
-                C_DecryptInit: (*list_ptr)
-                    .C_DecryptInit
-                    .ok_or(Error::Module("C_DecryptInit function not found"))?,
-                C_Decrypt: (*list_ptr)
-                    .C_Decrypt
-                    .ok_or(Error::Module("C_Decrypt function not found"))?,
-                C_DecryptUpdate: (*list_ptr)
-                    .C_DecryptUpdate
-                    .ok_or(Error::Module("C_DecryptUpdate function not found"))?,
-                C_DecryptFinal: (*list_ptr)
-                    .C_DecryptFinal
-                    .ok_or(Error::Module("C_DecryptFinal function not found"))?,
-                C_DigestInit: (*list_ptr)
-                    .C_DigestInit
-                    .ok_or(Error::Module("C_DigestInit function not found"))?,
-                C_Digest: (*list_ptr)
-                    .C_Digest
-                    .ok_or(Error::Module("C_Digest function not found"))?,
-                C_DigestUpdate: (*list_ptr)
-                    .C_DigestUpdate
-                    .ok_or(Error::Module("C_DigestUpdate function not found"))?,
-                C_DigestKey: (*list_ptr)
-                    .C_DigestKey
-                    .ok_or(Error::Module("C_DigestKey function not found"))?,
-                C_DigestFinal: (*list_ptr)
-                    .C_DigestFinal
-                    .ok_or(Error::Module("C_DigestFinal function not found"))?,
-                C_SignInit: (*list_ptr)
-                    .C_SignInit
-                    .ok_or(Error::Module("C_SignInit function not found"))?,
-                C_Sign: (*list_ptr)
-                    .C_Sign
-                    .ok_or(Error::Module("C_Sign function not found"))?,
-                C_SignUpdate: (*list_ptr)
-                    .C_SignUpdate
-                    .ok_or(Error::Module("C_SignUpdate function not found"))?,
-                C_SignFinal: (*list_ptr)
-                    .C_SignFinal
-                    .ok_or(Error::Module("C_SignFinal function not found"))?,
-                C_SignRecoverInit: (*list_ptr)
-                    .C_SignRecoverInit
-                    .ok_or(Error::Module("C_SignRecoverInit function not found"))?,
-                C_SignRecover: (*list_ptr)
-                    .C_SignRecover
-                    .ok_or(Error::Module("C_SignRecover function not found"))?,
-                C_VerifyInit: (*list_ptr)
-                    .C_VerifyInit
-                    .ok_or(Error::Module("C_VerifyInit function not found"))?,
-                C_Verify: (*list_ptr)
-                    .C_Verify
-                    .ok_or(Error::Module("C_Verify function not found"))?,
-                C_VerifyUpdate: (*list_ptr)
-                    .C_VerifyUpdate
-                    .ok_or(Error::Module("C_VerifyUpdate function not found"))?,
-                C_VerifyFinal: (*list_ptr)
-                    .C_VerifyFinal
-                    .ok_or(Error::Module("C_VerifyFinal function not found"))?,
-                C_VerifyRecoverInit: (*list_ptr)
-                    .C_VerifyRecoverInit
-                    .ok_or(Error::Module("C_VerifyRecoverInit function not found"))?,
-                C_VerifyRecover: (*list_ptr)
-                    .C_VerifyRecover
-                    .ok_or(Error::Module("C_VerifyRecover function not found"))?,
-                C_DigestEncryptUpdate: (*list_ptr)
-                    .C_DigestEncryptUpdate
-                    .ok_or(Error::Module("C_DigestEncryptUpdate function not found"))?,
-                C_DecryptDigestUpdate: (*list_ptr)
-                    .C_DecryptDigestUpdate
-                    .ok_or(Error::Module("C_DecryptDigestUpdate function not found"))?,
-                C_SignEncryptUpdate: (*list_ptr)
-                    .C_SignEncryptUpdate
-                    .ok_or(Error::Module("C_SignEncryptUpdate function not found"))?,
-                C_DecryptVerifyUpdate: (*list_ptr)
-                    .C_DecryptVerifyUpdate
-                    .ok_or(Error::Module("C_DecryptVerifyUpdate function not found"))?,
-                C_GenerateKey: (*list_ptr)
-                    .C_GenerateKey
-                    .ok_or(Error::Module("C_GenerateKey function not found"))?,
-                C_GenerateKeyPair: (*list_ptr)
-                    .C_GenerateKeyPair
-                    .ok_or(Error::Module("C_GenerateKeyPair function not found"))?,
-                C_WrapKey: (*list_ptr)
-                    .C_WrapKey
-                    .ok_or(Error::Module("C_WrapKey function not found"))?,
-                C_UnwrapKey: (*list_ptr)
-                    .C_UnwrapKey
-                    .ok_or(Error::Module("C_UnwrapKey function not found"))?,
-                C_DeriveKey: (*list_ptr)
-                    .C_DeriveKey
-                    .ok_or(Error::Module("C_DeriveKey function not found"))?,
-                C_SeedRandom: (*list_ptr)
-                    .C_SeedRandom
-                    .ok_or(Error::Module("C_SeedRandom function not found"))?,
-                C_GenerateRandom: (*list_ptr)
-                    .C_GenerateRandom
-                    .ok_or(Error::Module("C_GenerateRandom function not found"))?,
-                C_GetFunctionStatus: (*list_ptr)
-                    .C_GetFunctionStatus
-                    .ok_or(Error::Module("C_GetFunctionStatus function not found"))?,
-                C_CancelFunction: (*list_ptr)
-                    .C_CancelFunction
-                    .ok_or(Error::Module("C_CancelFunction function not found"))?,
+                C_Initialize: MaybeFn::new((*list_ptr).C_Initialize),
+                C_Finalize: MaybeFn::new((*list_ptr).C_Finalize),
+                C_GetInfo: MaybeFn::new((*list_ptr).C_GetInfo),
+                C_GetFunctionList: MaybeFn::new((*list_ptr).C_GetFunctionList),
+                C_GetSlotList: MaybeFn::new((*list_ptr).C_GetSlotList),
+                C_GetSlotInfo: MaybeFn::new((*list_ptr).C_GetSlotInfo),
+                C_GetTokenInfo: MaybeFn::new((*list_ptr).C_GetTokenInfo),
+                C_GetMechanismList: MaybeFn::new((*list_ptr).C_GetMechanismList),
+                C_GetMechanismInfo: MaybeFn::new((*list_ptr).C_GetMechanismInfo),
+                C_InitToken: MaybeFn::new((*list_ptr).C_InitToken),
+                C_InitPIN: MaybeFn::new((*list_ptr).C_InitPIN),
+                C_SetPIN: MaybeFn::new((*list_ptr).C_SetPIN),
+                C_OpenSession: MaybeFn::new((*list_ptr).C_OpenSession),
+                C_CloseSession: MaybeFn::new((*list_ptr).C_CloseSession),
+                C_CloseAllSessions: MaybeFn::new((*list_ptr).C_CloseAllSessions),
+                C_GetSessionInfo: MaybeFn::new((*list_ptr).C_GetSessionInfo),
+                C_GetOperationState: MaybeFn::new((*list_ptr).C_GetOperationState),
+                C_SetOperationState: MaybeFn::new((*list_ptr).C_SetOperationState),
+                C_Login: MaybeFn::new((*list_ptr).C_Login),
+                C_Logout: MaybeFn::new((*list_ptr).C_Logout),
+                C_CreateObject: MaybeFn::new((*list_ptr).C_CreateObject),
+                C_CopyObject: MaybeFn::new((*list_ptr).C_CopyObject),
+                C_DestroyObject: MaybeFn::new((*list_ptr).C_DestroyObject),
+                C_GetObjectSize: MaybeFn::new((*list_ptr).C_GetObjectSize),
+                C_GetAttributeValue: MaybeFn::new((*list_ptr).C_GetAttributeValue),
+                C_SetAttributeValue: MaybeFn::new((*list_ptr).C_SetAttributeValue),
+                C_FindObjectsInit: MaybeFn::new((*list_ptr).C_FindObjectsInit),
+                C_FindObjects: MaybeFn::new((*list_ptr).C_FindObjects),
+                C_FindObjectsFinal: MaybeFn::new((*list_ptr).C_FindObjectsFinal),
+                C_EncryptInit: MaybeFn::new((*list_ptr).C_EncryptInit),
+                C_Encrypt: MaybeFn::new((*list_ptr).C_Encrypt),
+                C_EncryptUpdate: MaybeFn::new((*list_ptr).C_EncryptUpdate),
+                C_EncryptFinal: MaybeFn::new((*list_ptr).C_EncryptFinal),
+                C_DecryptInit: MaybeFn::new((*list_ptr).C_DecryptInit),
+                C_Decrypt: MaybeFn::new((*list_ptr).C_Decrypt),
+                C_DecryptUpdate: MaybeFn::new((*list_ptr).C_DecryptUpdate),
+                C_DecryptFinal: MaybeFn::new((*list_ptr).C_DecryptFinal),
+                C_DigestInit: MaybeFn::new((*list_ptr).C_DigestInit),
+                C_Digest: MaybeFn::new((*list_ptr).C_Digest),
+                C_DigestUpdate: MaybeFn::new((*list_ptr).C_DigestUpdate),
+                C_DigestKey: MaybeFn::new((*list_ptr).C_DigestKey),
+                C_DigestFinal: MaybeFn::new((*list_ptr).C_DigestFinal),
+                C_SignInit: MaybeFn::new((*list_ptr).C_SignInit),
+                C_Sign: MaybeFn::new((*list_ptr).C_Sign),
+                C_SignUpdate: MaybeFn::new((*list_ptr).C_SignUpdate),
+                C_SignFinal: MaybeFn::new((*list_ptr).C_SignFinal),
+                C_SignRecoverInit: MaybeFn::new((*list_ptr).C_SignRecoverInit),
+                C_SignRecover: MaybeFn::new((*list_ptr).C_SignRecover),
+                C_VerifyInit: MaybeFn::new((*list_ptr).C_VerifyInit),
+                C_Verify: MaybeFn::new((*list_ptr).C_Verify),
+                C_VerifyUpdate: MaybeFn::new((*list_ptr).C_VerifyUpdate),
+                C_VerifyFinal: MaybeFn::new((*list_ptr).C_VerifyFinal),
+                C_VerifyRecoverInit: MaybeFn::new((*list_ptr).C_VerifyRecoverInit),
+                C_VerifyRecover: MaybeFn::new((*list_ptr).C_VerifyRecover),
+                C_DigestEncryptUpdate: MaybeFn::new((*list_ptr).C_DigestEncryptUpdate),
+                C_DecryptDigestUpdate: MaybeFn::new((*list_ptr).C_DecryptDigestUpdate),
+                C_SignEncryptUpdate: MaybeFn::new((*list_ptr).C_SignEncryptUpdate),
+                C_DecryptVerifyUpdate: MaybeFn::new((*list_ptr).C_DecryptVerifyUpdate),
+                C_GenerateKey: MaybeFn::new((*list_ptr).C_GenerateKey),
+                C_GenerateKeyPair: MaybeFn::new((*list_ptr).C_GenerateKeyPair),
+                C_WrapKey: MaybeFn::new((*list_ptr).C_WrapKey),
+                C_UnwrapKey: MaybeFn::new((*list_ptr).C_UnwrapKey),
+                C_DeriveKey: MaybeFn::new((*list_ptr).C_DeriveKey),
+                C_SeedRandom: MaybeFn::new((*list_ptr).C_SeedRandom),
+                C_GenerateRandom: MaybeFn::new((*list_ptr).C_GenerateRandom),
+                C_GetFunctionStatus: MaybeFn::new((*list_ptr).C_GetFunctionStatus),
+                C_CancelFunction: MaybeFn::new((*list_ptr).C_CancelFunction),
                 // Functions added in for Cryptoki Version 2.01 or later:
                 // to be compatible with PKCS#11 2.00 we do not fail during initialization
                 // but when the function will be called.
-                C_WaitForSlotEvent: (*list_ptr).C_WaitForSlotEvent,
+                C_WaitForSlotEvent: MaybeFn::new((*list_ptr).C_WaitForSlotEvent),
             })
         }
     }
@@ -431,7 +315,7 @@ impl Ctx {
             Some(mut args) => &mut args,
             None => ptr::null_mut(),
         };
-        match (self.C_Initialize)(init_args) {
+        match (self.C_Initialize.req()?)(init_args) {
             CKR_OK => {
                 self._is_initialized = true;
                 Ok(())
@@ -442,7 +326,7 @@ impl Ctx {
 
     pub fn finalize(&mut self) -> Result<(), Error> {
         self.initialized()?;
-        match (self.C_Finalize)(ptr::null_mut()) {
+        match (self.C_Finalize.req()?)(ptr::null_mut()) {
             CKR_OK => {
                 self._is_initialized = false;
                 Ok(())
@@ -454,7 +338,7 @@ impl Ctx {
     pub fn get_info(&self) -> Result<CK_INFO, Error> {
         self.initialized()?;
         let mut info = CK_INFO::new();
-        match (self.C_GetInfo)(&mut info) {
+        match (self.C_GetInfo.req()?)(&mut info) {
             CKR_OK => Ok(info),
             err => Err(Error::Pkcs11(err)),
         }
@@ -462,7 +346,7 @@ impl Ctx {
 
     pub fn get_function_list(&self) -> Result<CK_FUNCTION_LIST, Error> {
         let mut list = mem::MaybeUninit::uninit();
-        match (self.C_GetFunctionList)(&mut list.as_mut_ptr()) {
+        match (self.C_GetFunctionList.req()?)(&mut list.as_mut_ptr()) {
             CKR_OK => unsafe { Ok(*list.as_ptr()) },
             err => Err(Error::Pkcs11(err)),
         }
@@ -471,7 +355,11 @@ impl Ctx {
     pub fn get_slot_list(&self, token_present: bool) -> Result<Vec<CK_SLOT_ID>, Error> {
         self.initialized()?;
         let mut slots_len: CK_ULONG = 0;
-        match (self.C_GetSlotList)(CkFrom::from(token_present), ptr::null_mut(), &mut slots_len) {
+        match (self.C_GetSlotList.req()?)(
+            CkFrom::from(token_present),
+            ptr::null_mut(),
+            &mut slots_len,
+        ) {
             CKR_OK => {
                 // now slots_len contains the number of slots,
                 // and we can generate a vector with the right capacity
@@ -480,7 +368,11 @@ impl Ctx {
                 // in slots is.
                 let mut slots = Vec::<CK_SLOT_ID>::with_capacity(slots_len as usize);
                 let slots_ptr = slots.as_mut_ptr();
-                match (self.C_GetSlotList)(CkFrom::from(token_present), slots_ptr, &mut slots_len) {
+                match (self.C_GetSlotList.req()?)(
+                    CkFrom::from(token_present),
+                    slots_ptr,
+                    &mut slots_len,
+                ) {
                     CKR_OK => {
                         unsafe {
                             slots.set_len(slots_len as usize);
@@ -497,7 +389,7 @@ impl Ctx {
     pub fn get_slot_info(&self, slot_id: CK_SLOT_ID) -> Result<CK_SLOT_INFO, Error> {
         self.initialized()?;
         let mut info: CK_SLOT_INFO = Default::default();
-        match (self.C_GetSlotInfo)(slot_id, &mut info) {
+        match (self.C_GetSlotInfo.req()?)(slot_id, &mut info) {
             CKR_OK => Ok(info),
             err => Err(Error::Pkcs11(err)),
         }
@@ -506,7 +398,7 @@ impl Ctx {
     pub fn get_token_info(&self, slot_id: CK_SLOT_ID) -> Result<CK_TOKEN_INFO, Error> {
         self.initialized()?;
         let mut info: CK_TOKEN_INFO = Default::default();
-        match (self.C_GetTokenInfo)(slot_id, &mut info) {
+        match (self.C_GetTokenInfo.req()?)(slot_id, &mut info) {
             CKR_OK => Ok(info),
             err => Err(Error::Pkcs11(err)),
         }
@@ -515,12 +407,12 @@ impl Ctx {
     pub fn get_mechanism_list(&self, slot_id: CK_SLOT_ID) -> Result<Vec<CK_MECHANISM_TYPE>, Error> {
         self.initialized()?;
         let mut count: CK_ULONG = 0;
-        match (self.C_GetMechanismList)(slot_id, ptr::null_mut(), &mut count) {
+        match (self.C_GetMechanismList.req()?)(slot_id, ptr::null_mut(), &mut count) {
             CKR_OK => {
                 // see get_slot_list() for an explanation - it works the same way
                 let mut list = Vec::<CK_MECHANISM_TYPE>::with_capacity(count as usize);
                 let list_ptr = list.as_mut_ptr();
-                match (self.C_GetMechanismList)(slot_id, list_ptr, &mut count) {
+                match (self.C_GetMechanismList.req()?)(slot_id, list_ptr, &mut count) {
                     CKR_OK => {
                         unsafe {
                             list.set_len(count as usize);
@@ -541,7 +433,7 @@ impl Ctx {
     ) -> Result<CK_MECHANISM_INFO, Error> {
         self.initialized()?;
         let mut info: CK_MECHANISM_INFO = Default::default();
-        match (self.C_GetMechanismInfo)(slot_id, mechanism_type, &mut info) {
+        match (self.C_GetMechanismInfo.req()?)(slot_id, mechanism_type, &mut info) {
             CKR_OK => Ok(info),
             err => Err(Error::Pkcs11(err)),
         }
@@ -560,7 +452,7 @@ impl Ctx {
             Some(pin) => {
                 if let Ok(cpin) = CString::new(pin) {
                     let mut cpin_bytes = cpin.into_bytes();
-                    match (self.C_InitToken)(
+                    match (self.C_InitToken.req()?)(
                         slot_id,
                         cpin_bytes.as_mut_ptr(),
                         cpin_bytes.len() as CK_ULONG,
@@ -575,7 +467,7 @@ impl Ctx {
             }
             None => {
                 // CKF_PROTECTED_AUTHENTICATION_PATH requires a NULL pointer
-                match (self.C_InitToken)(slot_id, ptr::null_mut(), 0, formatted_label_ptr) {
+                match (self.C_InitToken.req()?)(slot_id, ptr::null_mut(), 0, formatted_label_ptr) {
                     CKR_OK => Ok(()),
                     err => Err(Error::Pkcs11(err)),
                 }
@@ -593,7 +485,7 @@ impl Ctx {
             Some(pin) => {
                 if let Ok(cpin) = CString::new(pin) {
                     let mut cpin_bytes = cpin.into_bytes();
-                    match (self.C_InitPIN)(
+                    match (self.C_InitPIN.req()?)(
                         session,
                         cpin_bytes.as_mut_ptr(),
                         cpin_bytes.len() as CK_ULONG,
@@ -605,7 +497,7 @@ impl Ctx {
                     Err(Error::InvalidInput("PIN contains a nul byte"))
                 }
             }
-            None => match (self.C_InitPIN)(session, ptr::null_mut(), 0) {
+            None => match (self.C_InitPIN.req()?)(session, ptr::null_mut(), 0) {
                 CKR_OK => Ok(()),
                 err => Err(Error::Pkcs11(err)),
             },
@@ -620,7 +512,7 @@ impl Ctx {
     ) -> Result<(), Error> {
         self.initialized()?;
         if old_pin.is_none() && new_pin.is_none() {
-            match (self.C_SetPIN)(session, ptr::null_mut(), 0, ptr::null_mut(), 0) {
+            match (self.C_SetPIN.req()?)(session, ptr::null_mut(), 0, ptr::null_mut(), 0) {
                 CKR_OK => Ok(()),
                 err => Err(Error::Pkcs11(err)),
             }
@@ -635,7 +527,7 @@ impl Ctx {
             }
             let mut old_cpin = old_cpin_res.unwrap().into_bytes();
             let mut new_cpin = new_cpin_res.unwrap().into_bytes();
-            match (self.C_SetPIN)(
+            match (self.C_SetPIN.req()?)(
                 session,
                 old_cpin.as_mut_ptr(),
                 old_cpin.len() as CK_ULONG,
@@ -659,7 +551,7 @@ impl Ctx {
     ) -> Result<CK_SESSION_HANDLE, Error> {
         self.initialized()?;
         let mut session: CK_SESSION_HANDLE = 0;
-        match (self.C_OpenSession)(
+        match (self.C_OpenSession.req()?)(
             slot_id,
             flags,
             application.unwrap_or(ptr::null_mut()),
@@ -673,7 +565,7 @@ impl Ctx {
 
     pub fn close_session(&self, session: CK_SESSION_HANDLE) -> Result<(), Error> {
         self.initialized()?;
-        match (self.C_CloseSession)(session) {
+        match (self.C_CloseSession.req()?)(session) {
             CKR_OK => Ok(()),
             err => Err(Error::Pkcs11(err)),
         }
@@ -681,7 +573,7 @@ impl Ctx {
 
     pub fn close_all_sessions(&self, slot_id: CK_SLOT_ID) -> Result<(), Error> {
         self.initialized()?;
-        match (self.C_CloseAllSessions)(slot_id) {
+        match (self.C_CloseAllSessions.req()?)(slot_id) {
             CKR_OK => Ok(()),
             err => Err(Error::Pkcs11(err)),
         }
@@ -690,7 +582,7 @@ impl Ctx {
     pub fn get_session_info(&self, session: CK_SESSION_HANDLE) -> Result<CK_SESSION_INFO, Error> {
         self.initialized()?;
         let mut info: CK_SESSION_INFO = Default::default();
-        match (self.C_GetSessionInfo)(session, &mut info) {
+        match (self.C_GetSessionInfo.req()?)(session, &mut info) {
             CKR_OK => Ok(info),
             err => Err(Error::Pkcs11(err)),
         }
@@ -699,11 +591,11 @@ impl Ctx {
     pub fn get_operation_state(&self, session: CK_SESSION_HANDLE) -> Result<Vec<CK_BYTE>, Error> {
         self.initialized()?;
         let mut state_length: CK_ULONG = 0;
-        match (self.C_GetOperationState)(session, ptr::null_mut(), &mut state_length) {
+        match (self.C_GetOperationState.req()?)(session, ptr::null_mut(), &mut state_length) {
             CKR_OK => {
                 let mut state: Vec<CK_BYTE> = Vec::with_capacity(state_length as usize);
                 let state_ptr = state.as_mut_ptr();
-                match (self.C_GetOperationState)(session, state_ptr, &mut state_length) {
+                match (self.C_GetOperationState.req()?)(session, state_ptr, &mut state_length) {
                     CKR_OK => {
                         unsafe {
                             state.set_len(state_length as usize);
@@ -726,7 +618,7 @@ impl Ctx {
     ) -> Result<(), Error> {
         self.initialized()?;
         let mut operation_state = operation_state;
-        match (self.C_SetOperationState)(
+        match (self.C_SetOperationState.req()?)(
             session,
             operation_state.as_mut_ptr(),
             operation_state.len() as CK_ULONG,
@@ -749,7 +641,7 @@ impl Ctx {
             Some(pin) => {
                 if let Ok(cpin) = CString::new(pin) {
                     let mut cpin_bytes = cpin.into_bytes();
-                    match (self.C_Login)(
+                    match (self.C_Login.req()?)(
                         session,
                         user_type,
                         cpin_bytes.as_mut_ptr(),
@@ -762,7 +654,7 @@ impl Ctx {
                     Err(Error::InvalidInput("PIN contains a nul byte"))
                 }
             }
-            None => match (self.C_Login)(session, user_type, ptr::null_mut(), 0) {
+            None => match (self.C_Login.req()?)(session, user_type, ptr::null_mut(), 0) {
                 CKR_OK => Ok(()),
                 err => Err(Error::Pkcs11(err)),
             },
@@ -783,12 +675,17 @@ impl Ctx {
         match pin {
             Some(pin) => {
                 let mut pin = pin.to_vec();
-                match (self.C_Login)(session, user_type, pin.as_mut_ptr(), pin.len() as CK_ULONG) {
+                match (self.C_Login.req()?)(
+                    session,
+                    user_type,
+                    pin.as_mut_ptr(),
+                    pin.len() as CK_ULONG,
+                ) {
                     CKR_OK => Ok(()),
                     err => Err(Error::Pkcs11(err)),
                 }
             }
-            None => match (self.C_Login)(session, user_type, ptr::null_mut(), 0) {
+            None => match (self.C_Login.req()?)(session, user_type, ptr::null_mut(), 0) {
                 CKR_OK => Ok(()),
                 err => Err(Error::Pkcs11(err)),
             },
@@ -797,7 +694,7 @@ impl Ctx {
 
     pub fn logout(&self, session: CK_SESSION_HANDLE) -> Result<(), Error> {
         self.initialized()?;
-        match (self.C_Logout)(session) {
+        match (self.C_Logout.req()?)(session) {
             CKR_OK => Ok(()),
             err => Err(Error::Pkcs11(err)),
         }
@@ -811,7 +708,7 @@ impl Ctx {
         self.initialized()?;
         let mut template = template.to_vec();
         let mut oh: CK_OBJECT_HANDLE = CK_INVALID_HANDLE;
-        match (self.C_CreateObject)(
+        match (self.C_CreateObject.req()?)(
             session,
             template.as_mut_ptr(),
             template.len() as CK_ULONG,
@@ -831,7 +728,7 @@ impl Ctx {
         self.initialized()?;
         let mut template = template.to_vec();
         let mut oh: CK_OBJECT_HANDLE = CK_INVALID_HANDLE;
-        match (self.C_CopyObject)(
+        match (self.C_CopyObject.req()?)(
             session,
             object,
             template.as_mut_ptr(),
@@ -849,7 +746,7 @@ impl Ctx {
         object: CK_OBJECT_HANDLE,
     ) -> Result<(), Error> {
         self.initialized()?;
-        match (self.C_DestroyObject)(session, object) {
+        match (self.C_DestroyObject.req()?)(session, object) {
             CKR_OK => Ok(()),
             err => Err(Error::Pkcs11(err)),
         }
@@ -862,7 +759,7 @@ impl Ctx {
     ) -> Result<CK_ULONG, Error> {
         self.initialized()?;
         let mut size: CK_ULONG = 0;
-        match (self.C_GetObjectSize)(session, object, &mut size) {
+        match (self.C_GetObjectSize.req()?)(session, object, &mut size) {
             CKR_OK => Ok(size),
             err => Err(Error::Pkcs11(err)),
         }
@@ -882,7 +779,7 @@ impl Ctx {
           C_GetAttributeValue.  Each attribute in the template whose value can be returned by the call to
           C_GetAttributeValue will be returned by the call to C_GetAttributeValue.
         */
-        match (self.C_GetAttributeValue)(
+        match (self.C_GetAttributeValue.req()?)(
             session,
             object,
             template.as_mut_ptr(),
@@ -904,7 +801,7 @@ impl Ctx {
     ) -> Result<(), Error> {
         self.initialized()?;
         let mut template = template.to_vec();
-        match (self.C_SetAttributeValue)(
+        match (self.C_SetAttributeValue.req()?)(
             session,
             object,
             template.as_mut_ptr(),
@@ -922,7 +819,11 @@ impl Ctx {
     ) -> Result<(), Error> {
         self.initialized()?;
         let mut template = template.to_vec();
-        match (self.C_FindObjectsInit)(session, template.as_mut_ptr(), template.len() as CK_ULONG) {
+        match (self.C_FindObjectsInit.req()?)(
+            session,
+            template.as_mut_ptr(),
+            template.len() as CK_ULONG,
+        ) {
             CKR_OK => Ok(()),
             err => Err(Error::Pkcs11(err)),
         }
@@ -936,7 +837,8 @@ impl Ctx {
         self.initialized()?;
         let mut list: Vec<CK_OBJECT_HANDLE> = Vec::with_capacity(max_object_count as usize);
         let mut count: CK_ULONG = 0;
-        match (self.C_FindObjects)(session, list.as_mut_ptr(), max_object_count, &mut count) {
+        match (self.C_FindObjects.req()?)(session, list.as_mut_ptr(), max_object_count, &mut count)
+        {
             CKR_OK => {
                 unsafe {
                     list.set_len(count as usize);
@@ -949,7 +851,7 @@ impl Ctx {
 
     pub fn find_objects_final(&self, session: CK_SESSION_HANDLE) -> Result<(), Error> {
         self.initialized()?;
-        match (self.C_FindObjectsFinal)(session) {
+        match (self.C_FindObjectsFinal.req()?)(session) {
             CKR_OK => Ok(()),
             err => Err(Error::Pkcs11(err)),
         }
@@ -963,7 +865,7 @@ impl Ctx {
     ) -> Result<(), Error> {
         self.initialized()?;
         let mut mechanism = *mechanism;
-        match (self.C_EncryptInit)(session, &mut mechanism, key) {
+        match (self.C_EncryptInit.req()?)(session, &mut mechanism, key) {
             CKR_OK => Ok(()),
             err => Err(Error::Pkcs11(err)),
         }
@@ -977,7 +879,7 @@ impl Ctx {
         self.initialized()?;
         let mut data = data.to_vec();
         let mut encryptedDataLen: CK_ULONG = 0;
-        match (self.C_Encrypt)(
+        match (self.C_Encrypt.req()?)(
             session,
             data.as_mut_ptr(),
             data.len() as CK_ULONG,
@@ -986,7 +888,7 @@ impl Ctx {
         ) {
             CKR_OK => {
                 let mut encryptedData: Vec<CK_BYTE> = Vec::with_capacity(encryptedDataLen as usize);
-                match (self.C_Encrypt)(
+                match (self.C_Encrypt.req()?)(
                     session,
                     data.as_mut_ptr(),
                     data.len() as CK_ULONG,
@@ -1014,7 +916,7 @@ impl Ctx {
         self.initialized()?;
         let mut part = part.to_vec();
         let mut encryptedPartLen: CK_ULONG = 0;
-        match (self.C_EncryptUpdate)(
+        match (self.C_EncryptUpdate.req()?)(
             session,
             part.as_mut_ptr(),
             part.len() as CK_ULONG,
@@ -1023,7 +925,7 @@ impl Ctx {
         ) {
             CKR_OK => {
                 let mut encryptedPart: Vec<CK_BYTE> = Vec::with_capacity(encryptedPartLen as usize);
-                match (self.C_EncryptUpdate)(
+                match (self.C_EncryptUpdate.req()?)(
                     session,
                     part.as_mut_ptr(),
                     part.len() as CK_ULONG,
@@ -1046,11 +948,11 @@ impl Ctx {
     pub fn encrypt_final(&self, session: CK_SESSION_HANDLE) -> Result<Vec<CK_BYTE>, Error> {
         self.initialized()?;
         let mut lastEncryptedPartLen: CK_ULONG = 0;
-        match (self.C_EncryptFinal)(session, ptr::null_mut(), &mut lastEncryptedPartLen) {
+        match (self.C_EncryptFinal.req()?)(session, ptr::null_mut(), &mut lastEncryptedPartLen) {
             CKR_OK => {
                 let mut lastEncryptedPart: Vec<CK_BYTE> =
                     Vec::with_capacity(lastEncryptedPartLen as usize);
-                match (self.C_EncryptFinal)(
+                match (self.C_EncryptFinal.req()?)(
                     session,
                     lastEncryptedPart.as_mut_ptr(),
                     &mut lastEncryptedPartLen,
@@ -1076,7 +978,7 @@ impl Ctx {
     ) -> Result<(), Error> {
         self.initialized()?;
         let mut mechanism = *mechanism;
-        match (self.C_DecryptInit)(session, &mut mechanism, key) {
+        match (self.C_DecryptInit.req()?)(session, &mut mechanism, key) {
             CKR_OK => Ok(()),
             err => Err(Error::Pkcs11(err)),
         }
@@ -1090,7 +992,7 @@ impl Ctx {
         self.initialized()?;
         let mut encrypted_data = encryptedData.to_vec();
         let mut dataLen: CK_ULONG = 0;
-        match (self.C_Decrypt)(
+        match (self.C_Decrypt.req()?)(
             session,
             encrypted_data.as_mut_ptr(),
             encrypted_data.len() as CK_ULONG,
@@ -1099,7 +1001,7 @@ impl Ctx {
         ) {
             CKR_OK => {
                 let mut data: Vec<CK_BYTE> = Vec::with_capacity(dataLen as usize);
-                match (self.C_Decrypt)(
+                match (self.C_Decrypt.req()?)(
                     session,
                     encrypted_data.as_mut_ptr(),
                     encrypted_data.len() as CK_ULONG,
@@ -1127,7 +1029,7 @@ impl Ctx {
         self.initialized()?;
         let mut encrypted_part = encryptedPart.to_vec();
         let mut partLen: CK_ULONG = 0;
-        match (self.C_DecryptUpdate)(
+        match (self.C_DecryptUpdate.req()?)(
             session,
             encrypted_part.as_mut_ptr(),
             encrypted_part.len() as CK_ULONG,
@@ -1136,7 +1038,7 @@ impl Ctx {
         ) {
             CKR_OK => {
                 let mut part: Vec<CK_BYTE> = Vec::with_capacity(partLen as usize);
-                match (self.C_DecryptUpdate)(
+                match (self.C_DecryptUpdate.req()?)(
                     session,
                     encrypted_part.as_mut_ptr(),
                     encrypted_part.len() as CK_ULONG,
@@ -1159,10 +1061,11 @@ impl Ctx {
     pub fn decrypt_final(&self, session: CK_SESSION_HANDLE) -> Result<Vec<CK_BYTE>, Error> {
         self.initialized()?;
         let mut lastPartLen: CK_ULONG = 0;
-        match (self.C_DecryptFinal)(session, ptr::null_mut(), &mut lastPartLen) {
+        match (self.C_DecryptFinal.req()?)(session, ptr::null_mut(), &mut lastPartLen) {
             CKR_OK => {
                 let mut lastPart: Vec<CK_BYTE> = Vec::with_capacity(lastPartLen as usize);
-                match (self.C_DecryptFinal)(session, lastPart.as_mut_ptr(), &mut lastPartLen) {
+                match (self.C_DecryptFinal.req()?)(session, lastPart.as_mut_ptr(), &mut lastPartLen)
+                {
                     CKR_OK => {
                         unsafe {
                             lastPart.set_len(lastPartLen as usize);
@@ -1183,7 +1086,7 @@ impl Ctx {
     ) -> Result<(), Error> {
         self.initialized()?;
         let mut mechanism = *mechanism;
-        match (self.C_DigestInit)(session, &mut mechanism) {
+        match (self.C_DigestInit.req()?)(session, &mut mechanism) {
             CKR_OK => Ok(()),
             err => Err(Error::Pkcs11(err)),
         }
@@ -1197,7 +1100,7 @@ impl Ctx {
         self.initialized()?;
         let mut data = data.to_vec();
         let mut digestLen: CK_ULONG = 0;
-        match (self.C_Digest)(
+        match (self.C_Digest.req()?)(
             session,
             data.as_mut_ptr(),
             data.len() as CK_ULONG,
@@ -1206,7 +1109,7 @@ impl Ctx {
         ) {
             CKR_OK => {
                 let mut digest: Vec<CK_BYTE> = Vec::with_capacity(digestLen as usize);
-                match (self.C_Digest)(
+                match (self.C_Digest.req()?)(
                     session,
                     data.as_mut_ptr(),
                     data.len() as CK_ULONG,
@@ -1228,7 +1131,7 @@ impl Ctx {
 
     pub fn digest_update(&self, session: CK_SESSION_HANDLE, part: &[CK_BYTE]) -> Result<(), Error> {
         let mut part = part.to_vec();
-        match (self.C_DigestUpdate)(session, part.as_mut_ptr(), part.len() as CK_ULONG) {
+        match (self.C_DigestUpdate.req()?)(session, part.as_mut_ptr(), part.len() as CK_ULONG) {
             CKR_OK => Ok(()),
             err => Err(Error::Pkcs11(err)),
         }
@@ -1240,7 +1143,7 @@ impl Ctx {
         key: CK_OBJECT_HANDLE,
     ) -> Result<(), Error> {
         self.initialized()?;
-        match (self.C_DigestKey)(session, key) {
+        match (self.C_DigestKey.req()?)(session, key) {
             CKR_OK => Ok(()),
             err => Err(Error::Pkcs11(err)),
         }
@@ -1249,10 +1152,10 @@ impl Ctx {
     pub fn digest_final(&self, session: CK_SESSION_HANDLE) -> Result<Vec<CK_BYTE>, Error> {
         self.initialized()?;
         let mut digestLen: CK_ULONG = 0;
-        match (self.C_DigestFinal)(session, ptr::null_mut(), &mut digestLen) {
+        match (self.C_DigestFinal.req()?)(session, ptr::null_mut(), &mut digestLen) {
             CKR_OK => {
                 let mut digest: Vec<CK_BYTE> = Vec::with_capacity(digestLen as usize);
-                match (self.C_DigestFinal)(session, digest.as_mut_ptr(), &mut digestLen) {
+                match (self.C_DigestFinal.req()?)(session, digest.as_mut_ptr(), &mut digestLen) {
                     CKR_OK => {
                         unsafe {
                             digest.set_len(digestLen as usize);
@@ -1274,7 +1177,7 @@ impl Ctx {
     ) -> Result<(), Error> {
         self.initialized()?;
         let mut mechanism = *mechanism;
-        match (self.C_SignInit)(session, &mut mechanism, key) {
+        match (self.C_SignInit.req()?)(session, &mut mechanism, key) {
             CKR_OK => Ok(()),
             err => Err(Error::Pkcs11(err)),
         }
@@ -1288,7 +1191,7 @@ impl Ctx {
         self.initialized()?;
         let mut data = data.to_vec();
         let mut signatureLen: CK_ULONG = 0;
-        match (self.C_Sign)(
+        match (self.C_Sign.req()?)(
             session,
             data.as_mut_ptr(),
             data.len() as CK_ULONG,
@@ -1297,7 +1200,7 @@ impl Ctx {
         ) {
             CKR_OK => {
                 let mut signature: Vec<CK_BYTE> = Vec::with_capacity(signatureLen as usize);
-                match (self.C_Sign)(
+                match (self.C_Sign.req()?)(
                     session,
                     data.as_mut_ptr(),
                     data.len() as CK_ULONG,
@@ -1320,7 +1223,7 @@ impl Ctx {
     pub fn sign_update(&self, session: CK_SESSION_HANDLE, part: &[CK_BYTE]) -> Result<(), Error> {
         self.initialized()?;
         let mut part = part.to_vec();
-        match (self.C_SignUpdate)(session, part.as_mut_ptr(), part.len() as CK_ULONG) {
+        match (self.C_SignUpdate.req()?)(session, part.as_mut_ptr(), part.len() as CK_ULONG) {
             CKR_OK => Ok(()),
             err => Err(Error::Pkcs11(err)),
         }
@@ -1329,10 +1232,11 @@ impl Ctx {
     pub fn sign_final(&self, session: CK_SESSION_HANDLE) -> Result<Vec<CK_BYTE>, Error> {
         self.initialized()?;
         let mut signatureLen: CK_ULONG = 0;
-        match (self.C_SignFinal)(session, ptr::null_mut(), &mut signatureLen) {
+        match (self.C_SignFinal.req()?)(session, ptr::null_mut(), &mut signatureLen) {
             CKR_OK => {
                 let mut signature: Vec<CK_BYTE> = Vec::with_capacity(signatureLen as usize);
-                match (self.C_SignFinal)(session, signature.as_mut_ptr(), &mut signatureLen) {
+                match (self.C_SignFinal.req()?)(session, signature.as_mut_ptr(), &mut signatureLen)
+                {
                     CKR_OK => {
                         unsafe {
                             signature.set_len(signatureLen as usize);
@@ -1354,7 +1258,7 @@ impl Ctx {
     ) -> Result<(), Error> {
         self.initialized()?;
         let mut mechanism = *mechanism;
-        match (self.C_SignRecoverInit)(session, &mut mechanism, key) {
+        match (self.C_SignRecoverInit.req()?)(session, &mut mechanism, key) {
             CKR_OK => Ok(()),
             err => Err(Error::Pkcs11(err)),
         }
@@ -1368,7 +1272,7 @@ impl Ctx {
         self.initialized()?;
         let mut data = data.to_vec();
         let mut signatureLen: CK_ULONG = 0;
-        match (self.C_SignRecover)(
+        match (self.C_SignRecover.req()?)(
             session,
             data.as_mut_ptr(),
             data.len() as CK_ULONG,
@@ -1377,7 +1281,7 @@ impl Ctx {
         ) {
             CKR_OK => {
                 let mut signature: Vec<CK_BYTE> = Vec::with_capacity(signatureLen as usize);
-                match (self.C_SignRecover)(
+                match (self.C_SignRecover.req()?)(
                     session,
                     data.as_mut_ptr(),
                     data.len() as CK_ULONG,
@@ -1405,7 +1309,7 @@ impl Ctx {
     ) -> Result<(), Error> {
         self.initialized()?;
         let mut mechanism = *mechanism;
-        match (self.C_VerifyInit)(session, &mut mechanism, key) {
+        match (self.C_VerifyInit.req()?)(session, &mut mechanism, key) {
             CKR_OK => Ok(()),
             err => Err(Error::Pkcs11(err)),
         }
@@ -1420,7 +1324,7 @@ impl Ctx {
         self.initialized()?;
         let mut data = data.to_vec();
         let mut signature = signature.to_vec();
-        match (self.C_Verify)(
+        match (self.C_Verify.req()?)(
             session,
             data.as_mut_ptr(),
             data.len() as CK_ULONG,
@@ -1435,7 +1339,7 @@ impl Ctx {
     pub fn verify_update(&self, session: CK_SESSION_HANDLE, part: &[CK_BYTE]) -> Result<(), Error> {
         self.initialized()?;
         let mut part = part.to_vec();
-        match (self.C_VerifyUpdate)(session, part.as_mut_ptr(), part.len() as CK_ULONG) {
+        match (self.C_VerifyUpdate.req()?)(session, part.as_mut_ptr(), part.len() as CK_ULONG) {
             CKR_OK => Ok(()),
             err => Err(Error::Pkcs11(err)),
         }
@@ -1448,7 +1352,11 @@ impl Ctx {
     ) -> Result<(), Error> {
         self.initialized()?;
         let mut signature = signature.to_vec();
-        match (self.C_VerifyFinal)(session, signature.as_mut_ptr(), signature.len() as CK_ULONG) {
+        match (self.C_VerifyFinal.req()?)(
+            session,
+            signature.as_mut_ptr(),
+            signature.len() as CK_ULONG,
+        ) {
             CKR_OK => Ok(()),
             err => Err(Error::Pkcs11(err)),
         }
@@ -1462,7 +1370,7 @@ impl Ctx {
     ) -> Result<(), Error> {
         self.initialized()?;
         let mut mechanism = *mechanism;
-        match (self.C_VerifyRecoverInit)(session, &mut mechanism, key) {
+        match (self.C_VerifyRecoverInit.req()?)(session, &mut mechanism, key) {
             CKR_OK => Ok(()),
             err => Err(Error::Pkcs11(err)),
         }
@@ -1476,7 +1384,7 @@ impl Ctx {
         self.initialized()?;
         let mut signature = signature.to_vec();
         let mut dataLen: CK_ULONG = 0;
-        match (self.C_VerifyRecover)(
+        match (self.C_VerifyRecover.req()?)(
             session,
             signature.as_mut_ptr(),
             signature.len() as CK_ULONG,
@@ -1485,7 +1393,7 @@ impl Ctx {
         ) {
             CKR_OK => {
                 let mut data: Vec<CK_BYTE> = Vec::with_capacity(dataLen as usize);
-                match (self.C_VerifyRecover)(
+                match (self.C_VerifyRecover.req()?)(
                     session,
                     signature.as_mut_ptr(),
                     signature.len() as CK_ULONG,
@@ -1513,7 +1421,7 @@ impl Ctx {
         self.initialized()?;
         let mut part = part.to_vec();
         let mut encryptedPartLen: CK_ULONG = 0;
-        match (self.C_DigestEncryptUpdate)(
+        match (self.C_DigestEncryptUpdate.req()?)(
             session,
             part.as_mut_ptr(),
             part.len() as CK_ULONG,
@@ -1522,7 +1430,7 @@ impl Ctx {
         ) {
             CKR_OK => {
                 let mut encryptedPart: Vec<CK_BYTE> = Vec::with_capacity(encryptedPartLen as usize);
-                match (self.C_DigestEncryptUpdate)(
+                match (self.C_DigestEncryptUpdate.req()?)(
                     session,
                     part.as_mut_ptr(),
                     part.len() as CK_ULONG,
@@ -1550,7 +1458,7 @@ impl Ctx {
         self.initialized()?;
         let mut encrypted_part = encryptedPart.to_vec();
         let mut partLen: CK_ULONG = 0;
-        match (self.C_DecryptDigestUpdate)(
+        match (self.C_DecryptDigestUpdate.req()?)(
             session,
             encrypted_part.as_mut_ptr(),
             encrypted_part.len() as CK_ULONG,
@@ -1559,7 +1467,7 @@ impl Ctx {
         ) {
             CKR_OK => {
                 let mut part: Vec<CK_BYTE> = Vec::with_capacity(partLen as usize);
-                match (self.C_DecryptDigestUpdate)(
+                match (self.C_DecryptDigestUpdate.req()?)(
                     session,
                     encrypted_part.as_mut_ptr(),
                     encrypted_part.len() as CK_ULONG,
@@ -1587,7 +1495,7 @@ impl Ctx {
         self.initialized()?;
         let mut part = part.to_vec();
         let mut encryptedPartLen: CK_ULONG = 0;
-        match (self.C_SignEncryptUpdate)(
+        match (self.C_SignEncryptUpdate.req()?)(
             session,
             part.as_mut_ptr(),
             part.len() as CK_ULONG,
@@ -1596,7 +1504,7 @@ impl Ctx {
         ) {
             CKR_OK => {
                 let mut encryptedPart: Vec<CK_BYTE> = Vec::with_capacity(encryptedPartLen as usize);
-                match (self.C_SignEncryptUpdate)(
+                match (self.C_SignEncryptUpdate.req()?)(
                     session,
                     part.as_mut_ptr(),
                     part.len() as CK_ULONG,
@@ -1624,7 +1532,7 @@ impl Ctx {
         self.initialized()?;
         let mut encrypted_part = encryptedPart;
         let mut partLen: CK_ULONG = 0;
-        match (self.C_DecryptVerifyUpdate)(
+        match (self.C_DecryptVerifyUpdate.req()?)(
             session,
             encrypted_part.as_mut_ptr(),
             encrypted_part.len() as CK_ULONG,
@@ -1633,7 +1541,7 @@ impl Ctx {
         ) {
             CKR_OK => {
                 let mut part: Vec<CK_BYTE> = Vec::with_capacity(partLen as usize);
-                match (self.C_DecryptVerifyUpdate)(
+                match (self.C_DecryptVerifyUpdate.req()?)(
                     session,
                     encrypted_part.as_mut_ptr(),
                     encrypted_part.len() as CK_ULONG,
@@ -1663,7 +1571,7 @@ impl Ctx {
         let mut mechanism = *mechanism;
         let mut template = template.to_vec();
         let mut object: CK_OBJECT_HANDLE = CK_INVALID_HANDLE;
-        match (self.C_GenerateKey)(
+        match (self.C_GenerateKey.req()?)(
             session,
             &mut mechanism,
             template.as_mut_ptr(),
@@ -1688,7 +1596,7 @@ impl Ctx {
         let mut private_key_template = privateKeyTemplate.to_vec();
         let mut pubOh: CK_OBJECT_HANDLE = CK_INVALID_HANDLE;
         let mut privOh: CK_OBJECT_HANDLE = CK_INVALID_HANDLE;
-        match (self.C_GenerateKeyPair)(
+        match (self.C_GenerateKeyPair.req()?)(
             session,
             &mut mechanism,
             public_key_template.as_mut_ptr(),
@@ -1713,7 +1621,7 @@ impl Ctx {
         self.initialized()?;
         let mut mechanism = *mechanism;
         let mut length: CK_ULONG = 0;
-        match (self.C_WrapKey)(
+        match (self.C_WrapKey.req()?)(
             session,
             &mut mechanism,
             wrappingKey,
@@ -1724,7 +1632,7 @@ impl Ctx {
             CKR_OK => {
                 if length > 0 {
                     let mut out: Vec<CK_BYTE> = Vec::with_capacity(length as usize);
-                    match (self.C_WrapKey)(
+                    match (self.C_WrapKey.req()?)(
                         session,
                         &mut mechanism,
                         wrappingKey,
@@ -1761,7 +1669,7 @@ impl Ctx {
         let mut wrapped_key = wrappedKey.to_vec();
         let mut template = template.to_vec();
         let mut oh: CK_OBJECT_HANDLE = CK_INVALID_HANDLE;
-        match (self.C_UnwrapKey)(
+        match (self.C_UnwrapKey.req()?)(
             session,
             &mut mechanism,
             unwrappingKey,
@@ -1787,7 +1695,7 @@ impl Ctx {
         let mut mechanism = *mechanism;
         let mut template = template.to_vec();
         let mut oh: CK_OBJECT_HANDLE = CK_INVALID_HANDLE;
-        match (self.C_DeriveKey)(
+        match (self.C_DeriveKey.req()?)(
             session,
             &mut mechanism,
             baseKey,
@@ -1802,7 +1710,7 @@ impl Ctx {
 
     pub fn seed_random(&self, session: CK_SESSION_HANDLE, seed: &[CK_BYTE]) -> Result<(), Error> {
         let mut seed = seed.to_vec();
-        match (self.C_SeedRandom)(session, seed.as_mut_ptr(), seed.len() as CK_ULONG) {
+        match (self.C_SeedRandom.req()?)(session, seed.as_mut_ptr(), seed.len() as CK_ULONG) {
             CKR_OK => Ok(()),
             err => Err(Error::Pkcs11(err)),
         }
@@ -1814,7 +1722,7 @@ impl Ctx {
         randomLength: CK_ULONG,
     ) -> Result<Vec<CK_BYTE>, Error> {
         let mut data: Vec<CK_BYTE> = Vec::with_capacity(randomLength as usize);
-        match (self.C_GenerateRandom)(session, data.as_mut_ptr(), randomLength) {
+        match (self.C_GenerateRandom.req()?)(session, data.as_mut_ptr(), randomLength) {
             CKR_OK => {
                 unsafe {
                     data.set_len(randomLength as usize);
@@ -1826,7 +1734,7 @@ impl Ctx {
     }
 
     pub fn get_function_status(&self, session: CK_SESSION_HANDLE) -> Result<CK_RV, Error> {
-        match (self.C_GetFunctionStatus)(session) {
+        match (self.C_GetFunctionStatus.req()?)(session) {
             CKR_OK => Ok(CKR_OK),
             CKR_FUNCTION_NOT_PARALLEL => Ok(CKR_FUNCTION_NOT_PARALLEL),
             err => Err(Error::Pkcs11(err)),
@@ -1834,7 +1742,7 @@ impl Ctx {
     }
 
     pub fn cancel_function(&self, session: CK_SESSION_HANDLE) -> Result<CK_RV, Error> {
-        match (self.C_CancelFunction)(session) {
+        match (self.C_CancelFunction.req()?)(session) {
             CKR_OK => Ok(CKR_OK),
             CKR_FUNCTION_NOT_PARALLEL => Ok(CKR_FUNCTION_NOT_PARALLEL),
             err => Err(Error::Pkcs11(err)),
@@ -1843,9 +1751,7 @@ impl Ctx {
 
     pub fn wait_for_slot_event(&self, flags: CK_FLAGS) -> Result<Option<CK_SLOT_ID>, Error> {
         let mut slotID: CK_SLOT_ID = 0;
-        let C_WaitForSlotEvent = self
-            .C_WaitForSlotEvent
-            .ok_or(Error::Module("C_WaitForSlotEvent function not found"))?;
+        let C_WaitForSlotEvent = self.C_WaitForSlotEvent.req()?;
         match C_WaitForSlotEvent(flags, &mut slotID, ptr::null_mut()) {
             CKR_OK => Ok(Some(slotID)),
             CKR_NO_EVENT => Ok(None),


### PR DESCRIPTION
Resolves #42 

Some PKCS#11 implementations, including the JPKI in Japan, do not have all of PKCS#11 defined functions.  To support these, the library should require the function on calling, instead of loading time.  This pull request proposes to support these implementations by making all functions optional.  When an implementation does not support the called function, the library returns `Error::UnavailableFunction` with the name of the function now.

Example Output:
```
Error: UnavailableFunction("C_WaitForSlotEvent")
```

Thank you for creating this library!