### PR TITLE
Upgrade the linux builds to use focal

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: SoftHSM installation
       run: |
-        sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu/ eoan universe"
+        sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu/ focal universe"
         sudo apt-get install -f libsofthsm2
         sudo usermod -a -G softhsm $USER
     - name: tarpaulin installation

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: SoftHSM installation
       run: |
-        sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu/ eoan universe"
+        sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu/ focal universe"
         sudo apt-get install -f libsofthsm2
         sudo usermod -a -G softhsm $USER
     - name: build


### PR DESCRIPTION
Eoan has been EoL'ed and hence the lack of release files anymore. See https://fridge.ubuntu.com/2020/07/17/ubuntu-19-10-eoan-ermine-end-of-life-reached-on-july-17-2020/