### PR TITLE
Fix use-after-free bug in Ctx::initialize

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -424,11 +424,11 @@ impl Ctx {
         }
     }
 
-    pub fn initialize(&mut self, init_args: Option<CK_C_INITIALIZE_ARGS>) -> Result<(), Error> {
+    pub fn initialize(&mut self, mut init_args: Option<CK_C_INITIALIZE_ARGS>) -> Result<(), Error> {
         self.not_initialized()?;
         // if no args are specified, library expects NULL
-        let init_args = match init_args {
-            Some(mut args) => &mut args,
+        let init_args = match &mut init_args {
+            Some(ref mut args) => args,
             None => ptr::null_mut(),
         };
         match (self.C_Initialize)(init_args) {


### PR DESCRIPTION
Previously, init_args was being destructured by value, causing it to be dropped before C_Initialize was called.  This caused undefined behavior.  I believe this fixes #49.

The fact that a bug in safe code caused this is a bit worrying.  In my opinion, all the function pointers in `CK_FUNCTION_LIST` should be marked as unsafe, and have safe wrappers that take references rather than raw pointers.